### PR TITLE
add edu year and edu month to exam maker submission proccess

### DIFF
--- a/pages/test-maker/create.vue
+++ b/pages/test-maker/create.vue
@@ -128,7 +128,7 @@
                   </validation-provider>
                 </v-col>
 
-                <v-col cols="12" md="4">
+                <v-col cols="12" md="2">
                   <validation-provider
                     v-slot="{ errors }"
                     name="test_type"
@@ -178,7 +178,7 @@
                 <!--                  </validation-provider>-->
                 <!--                </v-col>-->
 
-                <v-col cols="12" md="4">
+                <v-col cols="12" md="2">
                   <validation-provider
                     v-slot="{ errors }"
                     name="test_duration"
@@ -193,6 +193,40 @@
                       item-value="id"
                       :error-messages="errors"
                       label="Test duration"
+                      outlined
+                    />
+                  </validation-provider>
+                </v-col>
+                <v-col cols="12" md="2">
+                  <validation-provider
+                    v-slot="{ errors }"
+                    name="edu_year"
+                    rules="required"
+                  >
+                    <v-autocomplete
+                      dense
+                      :items="year_list"
+                      v-model="form.edu_year"
+                      :error-messages="errors"
+                      label="Year"
+                      outlined
+                    />
+                  </validation-provider>
+                </v-col>
+                <v-col cols="12" md="2">
+                  <validation-provider
+                    v-slot="{ errors }"
+                    name="edu_month"
+                    rules="required"
+                  >
+                    <v-autocomplete
+                      dense
+                      :items="month_list"
+                      v-model="form.edu_month"
+                      item-text="title"
+                      item-value="id"
+                      :error-messages="errors"
+                      label="Month"
                       outlined
                     />
                   </validation-provider>
@@ -1181,7 +1215,27 @@ export default {
         negative_point: false,
         file_original: "",
         paperID: this.$route.query.paperId ? this.$route.query.paperId : "",
+        edu_year: "",
+        edu_month: "",
       },
+      year_list: [
+        2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014,
+        2013,
+      ],
+      month_list: [
+        { id: 1, title: "January" },
+        { id: 2, title: "February" },
+        { id: 3, title: "March" },
+        { id: 4, title: "April" },
+        { id: 5, title: "May" },
+        { id: 6, title: "June" },
+        { id: 7, title: "July" },
+        { id: 8, title: "August" },
+        { id: 9, title: "September" },
+        { id: 10, title: "October" },
+        { id: 11, title: "November" },
+        { id: 12, title: "December" },
+      ],
       filter: {
         section: "",
         base: "",

--- a/pages/test-maker/edit/_id.vue
+++ b/pages/test-maker/edit/_id.vue
@@ -198,6 +198,41 @@
                   </validation-provider>
                 </v-col>
 
+                <v-col cols="12" md="2">
+                  <validation-provider
+                    v-slot="{ errors }"
+                    name="edu_year"
+                    rules="required"
+                  >
+                    <v-autocomplete
+                      dense
+                      :items="year_list"
+                      v-model="form.edu_year"
+                      :error-messages="errors"
+                      label="Year"
+                      outlined
+                    />
+                  </validation-provider>
+                </v-col>
+                <v-col cols="12" md="2">
+                  <validation-provider
+                    v-slot="{ errors }"
+                    name="edu_month"
+                    rules="required"
+                  >
+                    <v-autocomplete
+                      dense
+                      :items="month_list"
+                      v-model="form.edu_month"
+                      item-text="title"
+                      item-value="id"
+                      :error-messages="errors"
+                      label="Month"
+                      outlined
+                    />
+                  </validation-provider>
+                </v-col>
+
                 <!--                <v-col cols="12" md="4">-->
                 <!--                  <v-file-input-->
                 <!--                    dense-->
@@ -1171,8 +1206,28 @@ export default {
         paperID: "",
         negative_point: false,
         file_original: "",
+        edu_year: "",
+        edu_month: "",
       },
       file_original: "",
+      year_list: [
+        2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014,
+        2013,
+      ],
+      month_list: [
+        { id: 1, title: "January" },
+        { id: 2, title: "February" },
+        { id: 3, title: "March" },
+        { id: 4, title: "April" },
+        { id: 5, title: "May" },
+        { id: 6, title: "June" },
+        { id: 7, title: "July" },
+        { id: 8, title: "August" },
+        { id: 9, title: "September" },
+        { id: 10, title: "October" },
+        { id: 11, title: "November" },
+        { id: 12, title: "December" },
+      ],
       filter: {
         section: "",
         base: "",
@@ -1424,6 +1479,9 @@ export default {
           this.form.paperID = response.data.paperID;
           this.form.duration = response.data.azmoon_time;
           this.form.file_original = response.data.file_original;
+          this.form.edu_year = parseInt(response.data.edu_year);
+          this.form.edu_month = parseInt(response.data.edu_month);
+
           setTimeout(() => {
             this.form.title = response.data.title;
           }, 2000);


### PR DESCRIPTION
- **fix(sitemap): Fix default sitemap to static pages**
- **feat(seo): Add yandex verify file**
- **fix(create test): fix edit images**
- **feat(search): remove user data from search cards**
- **feat(content details): update related link beside preview gallery**
- **feat(school list): update country, state, city list loading api**
- **fix(search page): Fix update page title base on filter change**
- **fix(mathjax load): Update static file path**
- **fix(past papers): force user to wait upload proccess end before submit form**
- **feet(school finder): update school details api**
- **feat(exam details): Create a link to related past paper in exam details**
- **fix(style): update some style in search page and paper details**
- **feat(GET Token): create GET Token landing page**
- **fix(get-token): update some style**
- **fix(paper details): update related service buttons**
- **fix(user content submition forms): fix and update some concepts in content forms (include past papers, multimedia, forum)**
- **fix(submission form): update some other concept in form options**
- **fix(school finder): update some section of list card and detail card**
- **feat(school): update school list base on new changes in api**
- **fix(school): school infinte loading fix, disable autocomplete data in country,state, city filter**
- **feat(search content): update page meta title string to improve SEO**
- **feat(exam maker): add edu year and edu month to exam maker submission proccess**
