### PR TITLE
diable open leaveCommentDialog in load time

### DIFF
--- a/pages/school/_id/_slug.vue
+++ b/pages/school/_id/_slug.vue
@@ -1367,7 +1367,7 @@ export default {
         tour: "under-image-right",
       },
       help_loading: false,
-      leaveCommentDialog: true,
+      leaveCommentDialog: false,
       galleryDialog: false,
       facilitiesDialog: false,
 


### PR DESCRIPTION
- **feet(school comment): Enable the comment helper button with OpenAI, allowing users to add comments with the help of AI.**
- **fix(ai function): add chatgpt server side method to vercel build config**
- **fix(school comment): fix ai helper prompt**
- **fix(school comment): diable open leaveCommentDialog in load time**
