### PR TITLE
fix mathjax load

### DIFF
--- a/pages/exam/start/_id.vue
+++ b/pages/exam/start/_id.vue
@@ -168,7 +168,7 @@ export default {
       title: "Start online exam",
       script: [
         {
-          src: `${process.env.STORAGE_BASE_URL}/static/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
+          src: `${process.env.STORAGE_BASE_URL}/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
         },
       ],
     };

--- a/pages/qa/_id/_slug.vue
+++ b/pages/qa/_id/_slug.vue
@@ -1000,7 +1000,7 @@ export default {
     return {
       script: [
         {
-          src: `${process.env.STORAGE_BASE_URL}/static/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
+          src: `${process.env.STORAGE_BASE_URL}/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
         },
       ],
       title: this.contentData.title,

--- a/pages/test-maker/create.vue
+++ b/pages/test-maker/create.vue
@@ -1180,7 +1180,7 @@ export default {
       title: "New Exam",
       script: [
         {
-          src: `${process.env.STORAGE_BASE_URL}/static/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
+          src: `${process.env.STORAGE_BASE_URL}/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
           defer: true,
         },
       ],

--- a/pages/test-maker/edit/_id.vue
+++ b/pages/test-maker/edit/_id.vue
@@ -1172,7 +1172,7 @@ export default {
       title: "Update online exam",
       script: [
         {
-          src: `${process.env.STORAGE_BASE_URL}/static/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
+          src: `${process.env.STORAGE_BASE_URL}/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
           defer: true,
         },
       ],

--- a/pages/test/_id.vue
+++ b/pages/test/_id.vue
@@ -241,7 +241,7 @@ export default {
       // title: this.$refs["test-question"].innerText
       script: [
         {
-          src: `${process.env.STORAGE_BASE_URL}/static/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
+          src: `${process.env.STORAGE_BASE_URL}/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
           defer: true,
         },
       ],

--- a/pages/tutorial/_id/_slug.vue
+++ b/pages/tutorial/_id/_slug.vue
@@ -271,7 +271,7 @@ export default {
     return {
       script: [
         {
-          src: `${process.env.STORAGE_BASE_URL}/static/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
+          src: `${process.env.STORAGE_BASE_URL}/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
         },
       ],
       title: this.tutorialInfo.title,


### PR DESCRIPTION
- **feet(school comment): Enable the comment helper button with OpenAI, allowing users to add comments with the help of AI.**
- **fix(ai function): add chatgpt server side method to vercel build config**
- **fix(school comment): fix ai helper prompt**
- **fix(school comment): diable open leaveCommentDialog in load time**
- **fix(school comments): enable comments list section**
- **feat(security): enable check origin for ai api**
- **feat(school list): fixed score number decimal in data list to 1**
- **fix(debug): debug secound back login issue**
- **feat(school comment): load 20(perpage) comments  in school list page**
- **fix(parallel login, school comment, search filter): some issue in leave comment, some issue in search filter and exam details**
- **fix(parallel login): some issue in submit data and api headers**
- **fix(login): secound login when otp required in login proccess**
- **feet(school rating and sitemap): enable some part of rating details and init tmp sitemap for school list**
- **fix(school): update metadata and rating size issue**
- **fix(exam maker): csrf issue**
- **fix(mathjax load): update mathjax path to new server**
