### PR TITLE
enable mathjax rendering plugin. (refactor) 

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -82,6 +82,7 @@ export default {
     { src: "plugins/vuedraggable", ssr: false },
     // { src: 'plugins/aframe.js', ssr: false, mode: 'client' },
     { src: "plugins/gtag.js", mode: "client" },
+    { src: "plugins/mathjax.js", mode: "client" },
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/pages/exam/result/_id.vue
+++ b/pages/exam/result/_id.vue
@@ -508,11 +508,6 @@ export default {
   head() {
     return {
       title: "Online exam result",
-      script: [
-        {
-          src: `${process.env.STORAGE_BASE_URL}/static/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
-        },
-      ],
     };
   },
   async asyncData({ params, $axios }) {
@@ -656,34 +651,7 @@ export default {
     //End show question details
 
     renderMathJax() {
-      if (window.MathJax) {
-        window.MathJax.Hub.Config({
-          tex2jax: {
-            inlineMath: [
-              ["$", "$"],
-              ["\(", "\)"],
-            ],
-            displayMath: [
-              ["$$", "$$"],
-              ["\[", "\]"],
-            ],
-            processEscapes: true,
-            processEnvironments: true,
-          },
-          // Center justify equations in code and markdown cells. Elsewhere
-          // we use CSS to left justify single line equations in code cells.
-          displayAlign: "center",
-          "HTML-CSS": {
-            styles: { ".MathJax_Display": { margin: 0 } },
-            linebreaks: { automatic: true },
-          },
-        });
-        MathJax.Hub.Queue([
-          "Typeset",
-          window.MathJax.Hub,
-          this.$refs.mathJaxEl,
-        ]);
-      }
+      this.$renderMathJax(this.$refs.mathJaxEl);
     },
 
     openCrashReportDialog() {

--- a/pages/exam/start/_id.vue
+++ b/pages/exam/start/_id.vue
@@ -166,11 +166,6 @@ export default {
   head() {
     return {
       title: "Start online exam",
-      script: [
-        {
-          src: `${process.env.STORAGE_BASE_URL}/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
-        },
-      ],
     };
   },
   async asyncData({ params, redirect, $axios }) {
@@ -237,7 +232,7 @@ export default {
     }
 
     this.countDownTimer();
-    this.renderMathJax();
+    this.loadMathJax();
   },
   watch: {
     "examStats.answerData"(val) {
@@ -260,35 +255,8 @@ export default {
       }
     },
 
-    renderMathJax() {
-      if (window.MathJax) {
-        window.MathJax.Hub.Config({
-          tex2jax: {
-            inlineMath: [
-              ["$", "$"],
-              ["\(", "\)"],
-            ],
-            displayMath: [
-              ["$$", "$$"],
-              ["\[", "\]"],
-            ],
-            processEscapes: true,
-            processEnvironments: true,
-          },
-          // Center justify equations in code and markdown cells. Elsewhere
-          // we use CSS to left justify single line equations in code cells.
-          displayAlign: "center",
-          "HTML-CSS": {
-            styles: { ".MathJax_Display": { margin: 0 } },
-            linebreaks: { automatic: true },
-          },
-        });
-        MathJax.Hub.Queue([
-          "Typeset",
-          window.MathJax.Hub,
-          this.$refs.mathJaxEl,
-        ]);
-      }
+    loadMathJax() {
+      this.$renderMathJax(this.$refs.mathJaxEl);
     },
 
     endExam() {

--- a/pages/test-maker/edit/_id.vue
+++ b/pages/test-maker/edit/_id.vue
@@ -1170,12 +1170,6 @@ export default {
   head() {
     return {
       title: "Update online exam",
-      script: [
-        {
-          src: `${process.env.STORAGE_BASE_URL}/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
-          defer: true,
-        },
-      ],
     };
   },
   components: {
@@ -1645,9 +1639,7 @@ export default {
           this.test_list.push(...response.data.list);
 
           if (this.test_list.length) {
-            this.$nextTick(function () {
-              MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
-            });
+            this.$renderMathJax(this.$refs.mathJaxEl);
           }
           this.$refs["create-form"].examTestListLenght = this.tests.length;
 
@@ -1676,9 +1668,7 @@ export default {
           this.$refs["create-form"].examTestListLenght = this.tests.length;
 
           if (this.previewTestList.length) {
-            this.$nextTick(function () {
-              MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
-            });
+            this.$renderMathJax(this.$refs.mathJaxEl);
           }
         })
         .catch((err) => {
@@ -1688,34 +1678,7 @@ export default {
     },
 
     renderMathJax() {
-      if (window.MathJax) {
-        window.MathJax.Hub.Config({
-          tex2jax: {
-            inlineMath: [
-              ["$", "$"],
-              ["\(", "\)"],
-            ],
-            displayMath: [
-              ["$$", "$$"],
-              ["\[", "\]"],
-            ],
-            processEscapes: true,
-            processEnvironments: true,
-          },
-          // Center justify equations in code and markdown cells. Elsewhere
-          // we use CSS to left justify single line equations in code cells.
-          displayAlign: "center",
-          "HTML-CSS": {
-            styles: { ".MathJax_Display": { margin: 0 } },
-            linebreaks: { automatic: true },
-          },
-        });
-        MathJax.Hub.Queue([
-          "Typeset",
-          window.MathJax.Hub,
-          this.$refs.mathJaxEl,
-        ]);
-      }
+      this.$renderMathJax(this.$refs.mathJaxEl);
     },
 
     onScroll() {

--- a/pages/tutorial/_id/_slug.vue
+++ b/pages/tutorial/_id/_slug.vue
@@ -269,11 +269,6 @@ export default {
 
   head() {
     return {
-      script: [
-        {
-          src: `${process.env.STORAGE_BASE_URL}/MathJax/MathJax.js?config=TeX-MML-AM_CHTML`,
-        },
-      ],
       title: this.tutorialInfo.title,
     };
   },
@@ -391,38 +386,7 @@ export default {
       this.input = null;
     },
     renderMathJax() {
-      if (window.MathJax) {
-        window.MathJax.Hub.Config({
-          tex2jax: {
-            inlineMath: [
-              ["$", "$"],
-              ["\(", "\)"],
-            ],
-            displayMath: [
-              ["$$", "$$"],
-              ["\[", "\]"],
-            ],
-            processEscapes: true,
-            processEnvironments: true,
-          },
-          // Center justify equations in code and markdown cells. Elsewhere
-          // we use CSS to left justify single line equations in code cells.
-          displayAlign: "center",
-          "HTML-CSS": {
-            styles: { ".MathJax_Display": { margin: 0 } },
-            linebreaks: { automatic: true },
-            availableFonts: ["Asana Math"],
-            preferredFont: "Asana Math",
-            webFont: "Asana Math-Web",
-            imageFont: null,
-          },
-        });
-        window.MathJax.Hub.Queue([
-          "Typeset",
-          window.MathJax.Hub,
-          this.$refs.mathJaxEl,
-        ]);
-      }
+      this.$renderMathJax(this.$refs.mathJaxEl);
     },
     handleScroll() {
       if (window.scrollY > 1000) this.expandListMenu = false;

--- a/plugins/mathjax.js
+++ b/plugins/mathjax.js
@@ -1,0 +1,65 @@
+export default ({ app }, inject) => {
+  if (process.client) {
+    const loadMathJax = () => {
+      return new Promise((resolve, reject) => {
+        // Check if MathJax is already loaded
+        if (window.MathJax) {
+          resolve();
+          return;
+        }
+
+        // Load MathJax from CDN
+        const script = document.createElement("script");
+        script.src =
+          "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML";
+        script.async = true;
+        document.head.appendChild(script);
+
+        script.onload = () => {
+          // Set MathJax configuration once it's loaded
+          if (window.MathJax) {
+            window.MathJax.Hub.Config({
+              tex2jax: {
+                inlineMath: [
+                  ["$", "$"],
+                  ["\\(", "\\)"],
+                ],
+                displayMath: [
+                  ["$$", "$$"],
+                  ["\\[", "\\]"],
+                ],
+                processEscapes: true,
+                processEnvironments: true,
+              },
+              displayAlign: "center",
+              "HTML-CSS": {
+                styles: { ".MathJax_Display": { margin: 0 } },
+                linebreaks: { automatic: true },
+              },
+            });
+            resolve();
+          } else {
+            reject("MathJax failed to load");
+          }
+        };
+
+        script.onerror = () => {
+          reject("MathJax script failed to load");
+        };
+      });
+    };
+
+    // Inject the renderMathJax function into the app
+    inject("renderMathJax", async (el) => {
+      try {
+        await loadMathJax(); // Ensure MathJax is fully loaded
+        if (window.MathJax) {
+          // Re-render the math content inside the provided element
+          window.MathJax.Hub.Queue(["Typeset", window.MathJax.Hub, el]);
+        }
+      } catch (error) {
+        console.error("Error rendering MathJax:", error);
+      }
+    });
+  }
+};


### PR DESCRIPTION
- **feet(school comment): Enable the comment helper button with OpenAI, allowing users to add comments with the help of AI.**
- **fix(ai function): add chatgpt server side method to vercel build config**
- **fix(school comment): fix ai helper prompt**
- **fix(school comment): diable open leaveCommentDialog in load time**
- **fix(school comments): enable comments list section**
- **feat(security): enable check origin for ai api**
- **feat(school list): fixed score number decimal in data list to 1**
- **fix(debug): debug secound back login issue**
- **feat(school comment): load 20(perpage) comments  in school list page**
- **fix(parallel login, school comment, search filter): some issue in leave comment, some issue in search filter and exam details**
- **fix(parallel login): some issue in submit data and api headers**
- **fix(login): secound login when otp required in login proccess**
- **feet(school rating and sitemap): enable some part of rating details and init tmp sitemap for school list**
- **fix(school): update metadata and rating size issue**
- **fix(exam maker): csrf issue**
- **fix(mathjax load): update mathjax path to new server**
- **feat(matjax): enable a plugin for render mathjax**
