### PR TITLE
🎯Fix: Implement Board-Specific Classification Filter in Paper Submission Form

### DIFF
--- a/pages/user/paper/create.vue
+++ b/pages/user/paper/create.vue
@@ -18,6 +18,7 @@
           v-model="isFormValid"
           lazy-validation
           @submit.prevent="onSubmit"
+          autocomplete="off"
         >
           <v-row>
             <v-col
@@ -35,6 +36,7 @@
                 item-value="id"
                 label="Board"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -52,6 +54,7 @@
                 item-title="title"
                 label="Grade"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -69,6 +72,7 @@
                 item-title="title"
                 label="Subject"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -98,6 +102,7 @@
                 label="Classification"
                 placeholder="Select a board first"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -120,6 +125,7 @@
                 item-title="title"
                 label="Solution Availability"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -135,6 +141,7 @@
                 item-title="title"
                 label="Difficulty Level"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -150,6 +157,7 @@
                 :rules="[(v) => !!v || 'Year is required']"
                 label="Year"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -167,6 +175,7 @@
                 item-value="id"
                 label="Month"
                 color="#FFB300"
+                autocomplete="off" 
               />
             </v-col>
             <v-col
@@ -182,6 +191,7 @@
                 item-value="id"
                 label="Testing Scope"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
 
@@ -199,6 +209,7 @@
                 item-value="id"
                 label="State"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -215,6 +226,7 @@
                 item-value="id"
                 label="Area"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -231,6 +243,7 @@
                 item-value="id"
                 label="School"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
 
@@ -246,6 +259,7 @@
                 :rules="[(v) => !!v || 'Title is required']"
                 label="Title"
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -268,6 +282,7 @@
                 persistent-hint
                 placeholder="A brief overview of the content, outlining sections, topics, and question formats."
                 color="#FFB300"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -288,6 +303,7 @@
                 prepend-inner-icon="mdi-file-pdf-box"
                 append-icon="mdi-folder-open"
                 @change="uploadFile('file_pdf', $event)"
+                autocomplete="off"
               />
             </v-col>
             <v-col
@@ -348,6 +364,7 @@
                     item-value="id"
                     label="Select file type"
                     color="#FFB300"
+                    autocomplete="off"
                   />
                 </v-col>
                 <v-col

--- a/pages/user/paper/create.vue
+++ b/pages/user/paper/create.vue
@@ -91,9 +91,12 @@
                 density="compact"
                 variant="outlined"
                 :items="test_type_list"
+                :loading="test_type_loading"
+                :disabled="!formData.section || test_type_loading"
                 item-value="id"
                 item-title="title"
                 label="Classification"
+                placeholder="Select a board first"
                 color="#FFB300"
               />
             </v-col>
@@ -482,6 +485,7 @@ const file_pdf_loading = ref(false)
 const file_word_loading = ref(false)
 const file_answer_loading = ref(false)
 const file_extra_loading = ref(false)
+const test_type_loading = ref(false)
 
 const section_list = ref([])
 const grade_list = ref([])
@@ -586,6 +590,45 @@ const getTypeList = async (type, parent = '') => {
   }
   catch (err) {
     $toast.error(err)
+  }
+}
+
+const handleClassificationError = (error) => {
+  console.error('Classification loading error:', error)
+  $toast.error('Unable to load paper types. Please try selecting the board again.')
+  test_type_list.value = []
+  formData.test_type = ''
+}
+
+const getClassificationTypes = async (sectionId) => {
+  if (!sectionId) {
+    test_type_list.value = []
+    return
+  }
+
+  test_type_loading.value = true
+  try {
+    const params = { 
+      type: 'test_type',
+      section_id: sectionId 
+    }
+    const response = await useApiService.get('/api/v1/types/list', params)
+    
+    // The API should return board-specific classifications including:
+    // - General resources (Coursebook, Workbook) for all boards
+    // - CIE papers (Paper 1, Paper 2, etc.) for CIE board
+    // - Edexcel papers and Units for Edexcel board
+    // - Other board-specific classifications
+    test_type_list.value = response.data || []
+    
+    // Handle empty response
+    if (!response.data || response.data.length === 0) {
+      console.warn('No classification types returned for board:', sectionId)
+    }
+  } catch (err) {
+    handleClassificationError(err)
+  } finally {
+    test_type_loading.value = false
   }
 }
 
@@ -812,11 +855,13 @@ watch(
     formData.base = ''
     formData.lesson = ''
     formData.topics = []
+    formData.test_type = ''
     grade_list.value = []
     lesson_list.value = []
     topic_list.value = []
 
     getTypeList('base', val)
+    getClassificationTypes(val)
     if (formData.area) getTypeList('school')
   },
 )
@@ -878,9 +923,13 @@ watch(
 
 onMounted(() => {
   getTypeList('section')
-  getTypeList('test_type')
   getTypeList('state')
   getExtraFileType()
+  
+  // Load classifications if board is already selected (from user state)
+  if (formData.section) {
+    getClassificationTypes(formData.section)
+  }
 })
 </script>
 


### PR DESCRIPTION
Implemented dynamic board-specific classification filtering that mirrors the proven approach from the search page filter.

 🔧**Core Functionality**
- Added Loading State: New `test_type_loading` ref to provide visual feedback during API calls
- New API Function: `getClassificationTypes(sectionId)` that fetches classifications specific to the selected board
- Enhanced Board Watcher: Modified existing board selection watcher to trigger classification reload and clear invalid selections
- Template Updates: Added loading, disabled states, and placeholder text to classification dropdown
- Disable browser autocomplete form field

Fixes (https://github.com/GamaEdtech/gamatrain-front/issues/417)