### PR TITLE
fix: Update button styles and layout for paper detail

### DIFF
--- a/components/paper/detail/ContentInfo.vue
+++ b/components/paper/detail/ContentInfo.vue
@@ -102,13 +102,20 @@
       >
         <div v-if="contentData?.files?.word.exist">
           <v-btn
+            class="mb-2"
             block
             size="large"
+            variant="flat"
             color="primary"
-            class="mb-2"
             :loading="qWordFileDownloadLoading"
             @click="startDownload('q_word')"
           >
+            <v-icon
+              size="x-large"
+              class="btn-icon"
+            >
+              mdi-file-word-box
+            </v-icon>
             Download Question Doc
             {{
               contentData?.files?.word.price > 0
@@ -121,6 +128,7 @@
           <v-btn
             class="mb-2 text-white font-weight-bold"
             block
+            variant="flat"
             size="large"
             color="#E60012"
             :loading="qPdfFileDownloadLoading"
@@ -128,7 +136,7 @@
           >
             <v-icon
               size="x-large"
-              class="mr-1"
+              class="btn-icon"
             >
               mdi-file-pdf-box
             </v-icon>
@@ -145,6 +153,7 @@
             v-show="contentData?.files.answer.ext == 'pdf'"
             class="mb-2 font-weight-bold"
             block
+            variant="flat"
             size="large"
             color="teal accent-3"
             :loading="answerFileDownloadLoading"
@@ -152,7 +161,7 @@
           >
             <v-icon
               size="x-large"
-              class="mr-1"
+              class="btn-icon"
             >
               mdi-file-pdf-box
             </v-icon>
@@ -165,18 +174,19 @@
           </v-btn>
           <v-btn
             v-show="contentData?.files.answer.ext == 'word'"
+            class="mb-2"
             block
             color="primary"
+            variant="flat"
             size="large"
-            class="mb-2"
             :loading="answerFileDownloadLoading"
             @click="startDownload('a_file')"
           >
             <v-icon
               size="x-large"
-              class="mr-1"
+              class="btn-icon"
             >
-              mdi-file-pdf-box
+              mdi-file-word-box
             </v-icon>
             Download Answer Doc
             {{
@@ -192,19 +202,28 @@
           <v-btn
             v-for="(extra, index) in contentData.files.extra"
             :key="index"
+            class="mb-2 font-weight-bold"
             block
             color="blue"
+            variant="flat"
             size="large"
-            class="mb-2 font-weight-bold"
             :loading="extraFileDownloadLoading"
             @click="startDownload('extra', extra.id)"
           >
-            <template v-if="extra?.ext =='mp3'">
+            <template v-if="extra?.ext == 'mp3'">
               <v-icon
                 size="x-large"
-                class="mr-1"
+                class="btn-icon"
               >
                 mdi-volume-high
+              </v-icon>
+            </template>
+            <template v-if="extra?.ext == 'pdf'">
+              <v-icon
+                size="x-large"
+                class="btn-icon"
+              >
+                mdi-file-pdf-box
               </v-icon>
             </template>
             Download {{ extra.type_title ? extra.type_title : "Extra" }}
@@ -217,6 +236,7 @@
           block
           color="#5600e8"
           size="large"
+          variant="flat"
           class="mb-2 text-white font-weight-bold"
         >
           Begin Quiz
@@ -225,6 +245,7 @@
           v-else
           :to="`/test-maker/create?board=${contentData?.section}&grade=${contentData?.base}&subject=${contentData?.lesson}&paperId=${contentData?.id}`"
           block
+          variant="flat"
           outlined
           size="large"
           color="primary"
@@ -344,5 +365,10 @@ console.log('contentData.files.extra', props.contentData.files.extra)
 
 p {
   font-size: 1.3rem !important;
+}
+
+.btn-icon {
+  position: absolute;
+  left: 10px;
 }
 </style>

--- a/components/paper/detail/MobileOrder.vue
+++ b/components/paper/detail/MobileOrder.vue
@@ -11,12 +11,13 @@
               block
               color="primary"
               class="mb-2"
+              variant="flat"
               :loading="qWordFileDownloadLoading"
               @click="$emit('download', 'q_word')"
             >
               <v-icon
                 size="x-large"
-                class="mr-1"
+                class="btn-icon"
               >
                 mdi-file-pdf-box
               </v-icon>
@@ -32,13 +33,14 @@
             <v-btn
               class="mb-2 text-white font-weight-bold"
               block
+              variant="flat"
               color="#E60012"
               :loading="qPdfFileDownloadLoading"
               @click="$emit('download', 'q_pdf')"
             >
               <v-icon
                 size="x-large"
-                class="mr-1"
+                class="btn-icon"
               >
                 mdi-file-pdf-box
               </v-icon>
@@ -54,6 +56,7 @@
             <v-btn
               v-show="contentData?.files.answer.ext == 'pdf'"
               class="mb-2 font-weight-bold"
+              variant="flat"
               block
               color="teal accent-3"
               :loading="answerFileDownloadLoading"
@@ -61,7 +64,7 @@
             >
               <v-icon
                 size="x-large"
-                class="mr-1"
+                class="btn-icon"
               >
                 mdi-file-pdf-box
               </v-icon>
@@ -75,6 +78,7 @@
             <v-btn
               v-show="contentData?.files.answer.ext == 'word'"
               block
+              variant="flat"
               color="primary"
               class="mb-2"
               :loading="answerFileDownloadLoading"
@@ -99,15 +103,24 @@
               block
               color="blue"
               class="mb-2 font-weight-bold"
+              variant="flat"
               :loading="extraFileDownloadLoading"
               @click="$emit('download', 'extra', extra.id)"
             >
-              <template v-if="extra?.ext =='mp3'">
+              <template v-if="extra?.ext == 'mp3'">
                 <v-icon
                   size="x-large"
-                  class="mr-1"
+                  class="btn-icon"
                 >
                   mdi-volume-high
+                </v-icon>
+              </template>
+              <template v-if="extra?.ext == 'pdf'">
+                <v-icon
+                  size="x-large"
+                  class="btn-icon"
+                >
+                  mdi-file-pdf-box
                 </v-icon>
               </template>
               Download {{ extra.type_title ? extra.type_title : "Extra" }}
@@ -212,5 +225,12 @@ const _emits = defineEmits(['download', 'open-auth'])
 
 p {
   font-size: 1.3rem !important;
+}
+
+.btn-icon {
+  flex-shrink: 0;
+  margin-right: 8px;
+  position: absolute;
+  left: 10px;
 }
 </style>

--- a/pages/paper/[id]/[[slug]].vue
+++ b/pages/paper/[id]/[[slug]].vue
@@ -23,7 +23,7 @@
               <v-col
                 cols="12"
                 md="12"
-                lg="6"
+                lg="5"
                 xl="6"
                 class="px-8 px-lg=0 order-3 order-md-3 order-lg-2"
               >
@@ -106,7 +106,7 @@
                 class="order-1 order-md-2 order-lg-3"
                 sm="7"
                 md="9"
-                lg="3"
+                lg="4"
                 xl="3"
               >
                 <paper-detail-content-info


### PR DESCRIPTION
Refactored button components in ContentInfo.vue and MobileOrder.vue to use consistent 'variant="flat"' styling and improved icon positioning with a new .btn-icon class. Added support for displaying PDF icons for extra files. Adjusted grid layout in [id]/[[slug]].vue for better responsiveness.