### PR TITLE
feat: Add Online Page Viewer for Past Paper Preview

### DIFF
--- a/components/common/PdfPreviewDialog.vue
+++ b/components/common/PdfPreviewDialog.vue
@@ -1,0 +1,254 @@
+<template>
+  <v-dialog
+    v-model="dialog"
+    fullscreen
+    :scrim="false"
+    transition="dialog-bottom-transition"
+  >
+    <v-card>
+      <v-toolbar
+        color="primary"
+        dark
+      >
+        <v-btn
+          v-tooltip="'Close'"
+          icon
+          dark
+          @click="closeDialog"
+        >
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+        <v-toolbar-title>{{ title || "PDF Preview" }}</v-toolbar-title>
+        <v-spacer />
+        <v-btn
+          v-if="pdfUrl"
+          v-tooltip="'Open in new tab'"
+          icon
+          dark
+          @click="openInNewTab"
+        >
+          <v-icon>mdi-open-in-new</v-icon>
+        </v-btn>
+
+        <v-btn
+          v-if="pdfUrl"
+          v-tooltip="'Download PDF'"
+          icon
+          dark
+          :loading="downloadLoading"
+          @click="downloadPdf"
+        >
+          <v-icon>mdi-download</v-icon>
+        </v-btn>
+      </v-toolbar>
+
+      <v-card-text class="pa-0">
+        <div
+          v-if="loading"
+          class="d-flex justify-center align-center"
+          style="height: 80vh"
+        >
+          <v-progress-circular
+            indeterminate
+            color="primary"
+            size="64"
+          />
+        </div>
+
+        <div
+          v-else-if="error"
+          class="d-flex flex-column justify-center align-center"
+          style="height: 80vh"
+        >
+          <v-icon
+            size="64"
+            color="error"
+            class="mb-4"
+          >
+            mdi-alert-circle
+          </v-icon>
+          <h3 class="text-h6 mb-2">
+            Unable to load PDF
+          </h3>
+          <p class="text-body-1 text-center mb-4">
+            {{ error }}
+          </p>
+        </div>
+
+        <div
+          v-else-if="pdfUrl"
+          class="pdf-container"
+        >
+          <div
+            v-if="embedBlocked"
+            class="pdf-blocked-container"
+          >
+            <v-icon
+              size="64"
+              color="warning"
+              class="mb-4"
+            >
+              mdi-shield-alert
+            </v-icon>
+            <h3 class="text-h6 mb-3">
+              PDF Preview Restricted
+            </h3>
+            <p class="text-body-1 text-center mb-4">
+              This PDF cannot be previewed due to security restrictions.
+            </p>
+            <div class="d-flex gap-3 justify-center">
+              <v-btn
+                color="primary"
+                prepend-icon="mdi-open-in-new"
+                @click="openInNewTab"
+              >
+                Open PDF
+              </v-btn>
+              <v-btn
+                color="success"
+                :loading="downloadLoading"
+                prepend-icon="mdi-download"
+                @click="downloadPdf"
+              >
+                Download PDF
+              </v-btn>
+            </div>
+          </div>
+          <embed
+            v-else
+            :src="pdfUrl"
+            type="application/pdf"
+            referrerpolicy="strict-origin-when-cross-origin"
+            class="pdf-embed"
+            @error="handleEmbedError"
+            @load="handleEmbedSuccess"
+          >
+        </div>
+
+        <div
+          v-else
+          class="d-flex justify-center align-center"
+          style="height: 80vh"
+        >
+          <v-icon
+            size="64"
+            color="grey"
+          >
+            mdi-file-pdf-box
+          </v-icon>
+        </div>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  title: {
+    type: String,
+    default: '',
+  },
+  pdfUrl: {
+    type: String,
+    default: '',
+  },
+  fileName: {
+    type: String,
+    default: '',
+  },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const dialog = computed({
+  get: () => props.modelValue,
+  set: value => emit('update:modelValue', value),
+})
+
+const loading = ref(false)
+const error = ref('')
+const downloadLoading = ref(false)
+const embedBlocked = ref(false)
+
+watch(dialog, (newVal) => {
+  if (newVal && props.pdfUrl) {
+    embedBlocked.value = false
+  }
+})
+
+const closeDialog = () => {
+  dialog.value = false
+}
+
+const openInNewTab = () => {
+  if (props.pdfUrl) {
+    window.open(props.pdfUrl, '_blank')
+  }
+}
+
+const downloadPdf = async () => {
+  if (!props.pdfUrl) return
+
+  try {
+    downloadLoading.value = true
+    const FileSaver = await import('file-saver')
+    await FileSaver.saveAs(props.pdfUrl, props.fileName || 'document.pdf')
+  }
+  catch (err) {
+    console.error('Download error:', err)
+    window.open(props.pdfUrl, '_blank')
+  }
+  finally {
+    downloadLoading.value = false
+  }
+}
+
+const handleEmbedSuccess = () => {
+  embedBlocked.value = false
+}
+
+const handleEmbedError = () => {
+  embedBlocked.value = true
+  console.warn('PDF embed blocked, likely due to X-Frame-Options restriction')
+}
+</script>
+
+<style scoped>
+.pdf-container {
+  width: 100%;
+  height: calc(100vh - 64px);
+  overflow: hidden;
+}
+
+.pdf-iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.pdf-embed {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.pdf-blocked-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  text-align: center;
+  padding: 2rem;
+}
+
+@media (max-width: 768px) {
+  .pdf-container {
+    height: calc(100vh - 56px);
+  }
+}
+</style>

--- a/components/common/PdfPreviewDialog.vue
+++ b/components/common/PdfPreviewDialog.vue
@@ -141,17 +141,6 @@
           >
             <v-icon>mdi-rotate-right</v-icon>
           </v-btn>
-
-          <!-- External actions - Desktop -->
-          <v-btn
-            v-if="pdfUrl"
-            v-tooltip="'Open in new tab'"
-            icon
-            dark
-            @click="openInNewTab"
-          >
-            <v-icon>mdi-open-in-new</v-icon>
-          </v-btn>
         </template>
       </v-toolbar>
       <v-card-text class="pa-0">
@@ -186,26 +175,6 @@
           <p class="text-body-1 text-center mb-4">
             {{ error }}
           </p>
-          <div
-            v-if="pdfUrl"
-            class="d-flex gap-3 justify-center"
-          >
-            <v-btn
-              color="primary"
-              prepend-icon="mdi-open-in-new"
-              @click="openInNewTab"
-            >
-              Open PDF
-            </v-btn>
-            <v-btn
-              color="success"
-              :loading="downloadLoading"
-              prepend-icon="mdi-download"
-              @click="downloadPdf"
-            >
-              Download PDF
-            </v-btn>
-          </div>
         </div>
 
         <div
@@ -342,7 +311,6 @@ const dialog = computed({
 // State
 const loading = ref(false)
 const error = ref('')
-const downloadLoading = ref(false)
 const scrollContainer = ref<HTMLElement>()
 const showDebug = ref(false)
 const pdfSrc = ref<string | Uint8Array | Record<string, unknown>>('')
@@ -363,11 +331,6 @@ let navigationTimeout: ReturnType<typeof setTimeout> | null = null
 let resizeObserver: ResizeObserver | null = null
 function setInitialZoom() {
   zoom.value = isMobile.value ? 0.5 : 1
-  console.log(
-    `Initial zoom set to ${zoom.value * 100}% for ${
-      isMobile.value ? 'mobile' : 'desktop'
-    }`,
-  )
 }
 
 const estimatedPageHeight = computed(() => {
@@ -476,7 +439,6 @@ watch(currentPageFromScroll, (newPage) => {
 watch(
   renderedPages,
   (newPages) => {
-    console.log('Rendered pages changed:', newPages)
     newPages.forEach((pageNum) => {
       if (!loadedPages.value.has(pageNum) && !loadingPages.value.has(pageNum)) {
         loadPage(pageNum)
@@ -488,14 +450,6 @@ watch(
 
 watch([zoom, rotation], () => {
   renderKey.value++
-  // Reload visible pages
-  nextTick(() => {
-    renderedPages.value.forEach((pageNum) => {
-      if (loadedPages.value.has(pageNum)) {
-        // Page will re-render due to renderKey change
-      }
-    })
-  })
 })
 
 function clearTimeouts() {
@@ -559,7 +513,6 @@ async function loadPdf(url: string) {
     numPages.value = pdf.numPages
     currentPage.value = 1
     pageInput.value = 1
-    console.log(`PDF loaded with ${numPages.value} pages`)
   }
   catch (_e) {
     console.error('PDF loading error:', _e)
@@ -571,7 +524,6 @@ async function loadPdf(url: string) {
 }
 
 async function loadInitialPages() {
-  console.log('Loading initial pages...')
   await nextTick()
   if (numPages.value > 0) {
     await loadPage(1)
@@ -591,24 +543,13 @@ async function loadPage(pageNum: number): Promise<boolean> {
   }
 
   if (loadingPages.value.has(pageNum) || loadedPages.value.has(pageNum)) {
-    console.log(`Page ${pageNum} already loaded or loading`)
     return loadedPages.value.has(pageNum)
   }
-
-  console.log(`Loading page ${pageNum}...`)
   loadingPages.value.add(pageNum)
 
   try {
-    // Add a small delay to ensure the component is ready
     await new Promise(resolve => setTimeout(resolve, 10))
-
-    // Mark as loaded - the VuePdf component will handle the actual rendering
     loadedPages.value.add(pageNum)
-
-    console.log(
-      `Page ${pageNum} marked as loaded. Total loaded: ${loadedPages.value.size}`,
-    )
-
     return true
   }
   catch (error) {
@@ -626,39 +567,21 @@ async function goToPage(page: number) {
     console.warn(`Invalid navigation to page ${page}`)
     return
   }
-
-  console.log(`Navigating to page ${page}...`)
   navigating.value = true
 
   try {
-    // Clear any existing timeouts
     clearTimeouts()
-
-    // Update current page immediately
     currentPage.value = page
     resetPageInput()
-
-    // Ensure target page is loaded
     await loadPage(page)
-
-    // Force a re-render to ensure the pages are visible
     await nextTick()
-
-    // Calculate target position
     const targetPosition = Math.max(0, (page - 1) * estimatedPageHeight.value)
-
-    // Scroll to position
     scrollContainer.value.scrollTo({
       top: targetPosition,
       behavior: 'smooth',
     })
-
-    console.log(`Scrolled to position ${targetPosition} for page ${page}`)
-
-    // Reset navigating flag after scroll completes
     navigationTimeout = setTimeout(() => {
       navigating.value = false
-      console.log(`Navigation to page ${page} completed`)
     }, 700)
   }
   catch (error) {
@@ -712,7 +635,6 @@ function getPlaceholderStyle(pageNum: number) {
 }
 
 function onPageLoaded(pageNum: number, event) {
-  console.log(`VuePdf page ${pageNum} loaded successfully`, event)
   if (event && event.height) {
     pageHeights.value.set(pageNum, event.height)
   }
@@ -738,26 +660,6 @@ function rotate() {
 
 function closeDialog() {
   dialog.value = false
-}
-
-function openInNewTab() {
-  if (props.pdfUrl) window.open(props.pdfUrl, '_blank', 'noopener')
-}
-
-async function downloadPdf() {
-  if (!props.pdfUrl) return
-  try {
-    downloadLoading.value = true
-    const FileSaver = await import('file-saver')
-    await FileSaver.saveAs(props.pdfUrl, props.fileName || 'document.pdf')
-  }
-  catch (err) {
-    console.error('Download error:', err)
-    window.open(props.pdfUrl, '_blank', 'noopener')
-  }
-  finally {
-    downloadLoading.value = false
-  }
 }
 
 onMounted(async () => {

--- a/components/common/PdfPreviewDialog.vue
+++ b/components/common/PdfPreviewDialog.vue
@@ -6,6 +6,7 @@
     transition="dialog-bottom-transition"
   >
     <v-card>
+      <!-- Toolbar -->
       <v-toolbar
         color="primary"
         dark
@@ -18,8 +19,34 @@
         >
           <v-icon>mdi-close</v-icon>
         </v-btn>
+
         <v-toolbar-title>{{ title || "PDF Preview" }}</v-toolbar-title>
         <v-spacer />
+
+        <!-- Zoom / Rotate -->
+        <v-btn
+          icon
+          :disabled="!numPages"
+          @click="zoomOut"
+        >
+          <v-icon>mdi-magnify-minus-outline</v-icon>
+        </v-btn>
+        <v-btn
+          icon
+          :disabled="!numPages"
+          @click="zoomIn"
+        >
+          <v-icon>mdi-magnify-plus-outline</v-icon>
+        </v-btn>
+        <v-btn
+          icon
+          :disabled="!numPages"
+          @click="rotate"
+        >
+          <v-icon>mdi-rotate-right</v-icon>
+        </v-btn>
+
+        <!-- External actions -->
         <v-btn
           v-if="pdfUrl"
           v-tooltip="'Open in new tab'"
@@ -30,7 +57,7 @@
           <v-icon>mdi-open-in-new</v-icon>
         </v-btn>
 
-        <v-btn
+        <!-- <v-btn
           v-if="pdfUrl"
           v-tooltip="'Download PDF'"
           icon
@@ -39,10 +66,11 @@
           @click="downloadPdf"
         >
           <v-icon>mdi-download</v-icon>
-        </v-btn>
+        </v-btn> -->
       </v-toolbar>
 
       <v-card-text class="pa-0">
+        <!-- Loading -->
         <div
           v-if="loading"
           class="d-flex justify-center align-center"
@@ -55,6 +83,7 @@
           />
         </div>
 
+        <!-- Error -->
         <div
           v-else-if="error"
           class="d-flex flex-column justify-center align-center"
@@ -73,54 +102,47 @@
           <p class="text-body-1 text-center mb-4">
             {{ error }}
           </p>
+          <div
+            v-if="pdfUrl"
+            class="d-flex gap-3 justify-center"
+          >
+            <v-btn
+              color="primary"
+              prepend-icon="mdi-open-in-new"
+              @click="openInNewTab"
+            >
+              Open PDF
+            </v-btn>
+            <v-btn
+              color="success"
+              :loading="downloadLoading"
+              prepend-icon="mdi-download"
+              @click="downloadPdf"
+            >
+              Download PDF
+            </v-btn>
+          </div>
         </div>
 
+        <!-- PDF pages -->
         <div
-          v-else-if="pdfUrl"
-          class="pdf-container"
+          v-else-if="numPages"
+          class="pdf-scroll"
         >
           <div
-            v-if="embedBlocked"
-            class="pdf-blocked-container"
+            class="pdf-pages"
+            :style="pagesStyle"
           >
-            <v-icon
-              size="64"
-              color="warning"
-              class="mb-4"
-            >
-              mdi-shield-alert
-            </v-icon>
-            <h3 class="text-h6 mb-3">
-              PDF Preview Restricted
-            </h3>
-            <p class="text-body-1 text-center mb-4">
-              This PDF cannot be previewed due to security restrictions.
-            </p>
-            <div class="d-flex gap-3 justify-center">
-              <v-btn
-                color="primary"
-                prepend-icon="mdi-open-in-new"
-                @click="openInNewTab"
-              >
-                Open PDF
-              </v-btn>
-              <v-btn
-                color="success"
-                :loading="downloadLoading"
-                prepend-icon="mdi-download"
-                @click="downloadPdf"
-              >
-                Download PDF
-              </v-btn>
-            </div>
+            <!-- Render all pages -->
+            <VuePdf
+              v-for="p in numPages"
+              :key="p"
+              :src="pdfSrc"
+              :page="p"
+              :rotation="rotation"
+              class="pdf-page"
+            />
           </div>
-          <embed
-            v-else-if="dataUrl && !loading"
-            :src="dataUrl"
-            class="pdf-embed"
-            @error="handleEmbedError"
-            @load="handleEmbedSuccess"
-          >
         </div>
 
         <div
@@ -140,76 +162,110 @@
   </v-dialog>
 </template>
 
-<script setup>
-const props = defineProps({
-  modelValue: {
-    type: Boolean,
-    default: false,
-  },
-  title: {
-    type: String,
-    default: '',
-  },
-  pdfUrl: {
-    type: String,
-    default: '',
-  },
-  fileName: {
-    type: String,
-    default: '',
-  },
-})
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { VuePdf, createLoadingTask } from 'vue3-pdfjs/esm'
+import type { PDFDocumentProxy } from 'pdfjs-dist/types/src/display/api'
 
-const emit = defineEmits(['update:modelValue'])
+const props = defineProps<{
+  modelValue: boolean
+  title?: string
+  pdfUrl?: string
+  fileName?: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: boolean): void
+}>()
 
 const dialog = computed({
   get: () => props.modelValue,
-  set: value => emit('update:modelValue', value),
+  set: v => emit('update:modelValue', v),
 })
 
 const loading = ref(false)
 const error = ref('')
 const downloadLoading = ref(false)
-const embedBlocked = ref(false)
 
-const dataUrl = ref('')
-let currentObjectUrl = ''
+const pdfSrc = ref<string | Uint8Array | Record<string, unknown>>('')
+const numPages = ref(0)
 
-watch(dialog, async (newVal) => {
-  if (newVal && props.pdfUrl) {
-    embedBlocked.value = false
-    await convertToBase64(props.pdfUrl)
-  }
-  else {
-    dataUrl.value = ''
-  }
-})
+const zoom = ref(1)
+const rotation = ref(0)
+
+const pagesStyle = computed(() => ({
+  transform: `scale(${zoom.value})`,
+  transformOrigin: 'top left',
+}))
+
+watch(
+  () => dialog.value,
+  async (open) => {
+    if (open && props.pdfUrl) await loadPdf(props.pdfUrl)
+  },
+  { immediate: true },
+)
 
 watch(
   () => props.pdfUrl,
   async (u) => {
-    if (dialog.value && u) {
-      await convertToBase64(u)
-    }
+    if (dialog.value && u) await loadPdf(u)
     else {
-      dataUrl.value = ''
+      clearState()
     }
   },
 )
 
-const closeDialog = () => {
-  dialog.value = false
+function clearState() {
+  loading.value = false
+  error.value = ''
+  numPages.value = 0
+  pdfSrc.value = ''
+  zoom.value = 1
+  rotation.value = 0
 }
 
-const openInNewTab = () => {
-  if (props.pdfUrl) {
-    window.open(props.pdfUrl, '_blank')
+async function loadPdf(url: string) {
+  clearState()
+  if (!url) return
+  try {
+    loading.value = true
+    error.value = ''
+    pdfSrc.value = url
+
+    const task = createLoadingTask(pdfSrc.value)
+    const pdf: PDFDocumentProxy = await task.promise
+    numPages.value = pdf.numPages
+  }
+  catch (_e) {
+    console.error(_e)
+    error.value = 'Failed to load PDF.'
+  }
+  finally {
+    loading.value = false
   }
 }
 
-const downloadPdf = async () => {
-  if (!props.pdfUrl) return
+function zoomIn() {
+  zoom.value = Math.min(zoom.value + 0.1, 3)
+}
+function zoomOut() {
+  zoom.value = Math.max(zoom.value - 0.1, 0.3)
+}
+function rotate() {
+  rotation.value = (rotation.value + 90) % 360
+}
 
+function closeDialog() {
+  dialog.value = false
+}
+
+function openInNewTab() {
+  if (props.pdfUrl) window.open(props.pdfUrl, '_blank', 'noopener')
+}
+
+async function downloadPdf() {
+  if (!props.pdfUrl) return
   try {
     downloadLoading.value = true
     const FileSaver = await import('file-saver')
@@ -217,97 +273,37 @@ const downloadPdf = async () => {
   }
   catch (err) {
     console.error('Download error:', err)
-    window.open(props.pdfUrl, '_blank')
+    window.open(props.pdfUrl, '_blank', 'noopener')
   }
   finally {
     downloadLoading.value = false
   }
 }
 
-const handleEmbedSuccess = () => {
-  embedBlocked.value = false
-}
-
-const handleEmbedError = () => {
-  embedBlocked.value = true
-  error.value = 'Unable to preview this PDF.'
-}
-
-async function convertToBase64(url) {
-  try {
-    loading.value = true
-    error.value = ''
-    embedBlocked.value = false
-
-    if (currentObjectUrl) {
-      URL.revokeObjectURL(currentObjectUrl)
-      currentObjectUrl = ''
-    }
-
-    const resp = await fetch(url, { mode: 'cors', credentials: 'omit' })
-    if (!resp.ok) throw new Error('HTTP ' + resp.status)
-    const blob = await resp.blob()
-    const pdfBlob
-      = blob.type && blob.type.includes('pdf')
-        ? blob
-        : new Blob([blob], { type: 'application/pdf' })
-    const objectUrl = URL.createObjectURL(pdfBlob)
-    currentObjectUrl = objectUrl
-    dataUrl.value = objectUrl
-  }
-  catch (e) {
-    console.error(e)
-    if (url) {
-      dataUrl.value = url
-      return
-    }
-    error.value = 'Failed to load PDF.'
-    embedBlocked.value = true
-  }
-  finally {
-    loading.value = false
-  }
-}
-
-onBeforeUnmount(() => {
-  if (currentObjectUrl) {
-    URL.revokeObjectURL(currentObjectUrl)
-    currentObjectUrl = ''
-  }
-})
+onBeforeUnmount(() => {})
 </script>
 
 <style scoped>
-.pdf-container {
+.pdf-scroll {
   width: 100%;
   height: calc(100vh - 64px);
-  overflow: hidden;
+  overflow: auto;
+  background: #1212120a;
 }
 
-.pdf-iframe {
-  width: 100%;
-  height: 100%;
-  border: none;
+.pdf-pages {
+  padding: 24px;
 }
 
-.pdf-embed {
-  width: 100%;
-  height: 100%;
-  border: none;
-}
-
-.pdf-blocked-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  text-align: center;
-  padding: 2rem;
+.pdf-page {
+  display: block;
+  margin: 0 auto 24px auto;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+  background: white;
 }
 
 @media (max-width: 768px) {
-  .pdf-container {
+  .pdf-scroll {
     height: calc(100vh - 56px);
   }
 }

--- a/components/common/PdfPreviewDialog.vue
+++ b/components/common/PdfPreviewDialog.vue
@@ -10,6 +10,7 @@
       <v-toolbar
         color="primary"
         dark
+        :height="isMobile ? 56 : 64"
       >
         <v-btn
           v-tooltip="'Close'"
@@ -20,55 +21,139 @@
           <v-icon>mdi-close</v-icon>
         </v-btn>
 
-        <v-toolbar-title>{{ title || "PDF Preview" }}</v-toolbar-title>
-        <v-spacer />
+        <v-toolbar-title
+          class="toolbar-title"
+          :class="{ 'mobile-title': isMobile }"
+        >
+          {{ title || "PDF Preview" }}
+        </v-toolbar-title>
 
-        <!-- Zoom / Rotate -->
-        <v-btn
-          icon
-          :disabled="!numPages"
-          @click="zoomOut"
-        >
-          <v-icon>mdi-magnify-minus-outline</v-icon>
-        </v-btn>
-        <v-btn
-          icon
-          :disabled="!numPages"
-          @click="zoomIn"
-        >
-          <v-icon>mdi-magnify-plus-outline</v-icon>
-        </v-btn>
-        <v-btn
-          icon
-          :disabled="!numPages"
-          @click="rotate"
-        >
-          <v-icon>mdi-rotate-right</v-icon>
-        </v-btn>
+        <v-spacer v-if="!isMobile" />
 
-        <!-- External actions -->
-        <v-btn
-          v-if="pdfUrl"
-          v-tooltip="'Open in new tab'"
-          icon
-          dark
-          @click="openInNewTab"
-        >
-          <v-icon>mdi-open-in-new</v-icon>
-        </v-btn>
+        <!-- Mobile Layout -->
+        <template v-if="isMobile">
+          <!-- Page Navigation - Mobile -->
+          <div
+            v-if="numPages > 0"
+            class="mobile-nav-group"
+          >
+            <v-btn
+              icon
+              size="small"
+              :disabled="currentPage <= 1 || navigating"
+              @click="goToPreviousPage"
+            >
+              <v-icon size="20">
+                mdi-chevron-up
+              </v-icon>
+            </v-btn>
 
-        <!-- <v-btn
-          v-if="pdfUrl"
-          v-tooltip="'Download PDF'"
-          icon
-          dark
-          :loading="downloadLoading"
-          @click="downloadPdf"
-        >
-          <v-icon>mdi-download</v-icon>
-        </v-btn> -->
+            <div class="mobile-page-info">
+              <input
+                v-model.number="pageInput"
+                class="mobile-page-input"
+                density="compact"
+                variant="outlined"
+                hide-details
+                single-line
+                @keyup.enter="goToPageInput"
+                @blur="resetPageInput"
+              >
+              <span class="mobile-page-total">/ {{ numPages }}</span>
+            </div>
+
+            <v-btn
+              icon
+              size="small"
+              :disabled="currentPage >= numPages || navigating"
+              @click="goToNextPage"
+            >
+              <v-icon size="20">
+                mdi-chevron-down
+              </v-icon>
+            </v-btn>
+          </div>
+        </template>
+
+        <!-- Desktop Layout -->
+        <template v-else>
+          <!-- Page Navigation - Desktop -->
+          <template v-if="numPages > 0">
+            <v-btn
+              icon
+              :disabled="currentPage <= 1 || navigating"
+              @click="goToPreviousPage"
+            >
+              <v-icon>mdi-chevron-up</v-icon>
+            </v-btn>
+
+            <v-text-field
+              v-model.number="pageInput"
+              class="mx-2 page-input"
+              style="max-width: 80px"
+              density="compact"
+              variant="outlined"
+              hide-details
+              @keyup.enter="goToPageInput"
+              @blur="resetPageInput"
+            />
+
+            <span class="text-body-2 mx-2">/ {{ numPages }}</span>
+
+            <v-btn
+              icon
+              :disabled="currentPage >= numPages || navigating"
+              @click="goToNextPage"
+            >
+              <v-icon>mdi-chevron-down</v-icon>
+            </v-btn>
+          </template>
+
+          <!-- Zoom / Rotate - Desktop -->
+          <v-btn
+            icon
+            :disabled="!numPages"
+            @click="zoomOut"
+          >
+            <v-icon>mdi-magnify-minus-outline</v-icon>
+          </v-btn>
+
+          <v-chip
+            v-if="numPages"
+            class="mx-2"
+            small
+            outlined
+          >
+            {{ Math.round(zoom * 100) }}%
+          </v-chip>
+
+          <v-btn
+            icon
+            :disabled="!numPages"
+            @click="zoomIn"
+          >
+            <v-icon>mdi-magnify-plus-outline</v-icon>
+          </v-btn>
+          <v-btn
+            icon
+            :disabled="!numPages"
+            @click="rotate"
+          >
+            <v-icon>mdi-rotate-right</v-icon>
+          </v-btn>
+
+          <!-- External actions - Desktop -->
+          <v-btn
+            v-if="pdfUrl"
+            v-tooltip="'Open in new tab'"
+            icon
+            dark
+            @click="openInNewTab"
+          >
+            <v-icon>mdi-open-in-new</v-icon>
+          </v-btn>
+        </template>
       </v-toolbar>
-
       <v-card-text class="pa-0">
         <!-- Loading -->
         <div
@@ -83,7 +168,6 @@
           />
         </div>
 
-        <!-- Error -->
         <div
           v-else-if="error"
           class="d-flex flex-column justify-center align-center"
@@ -124,24 +208,87 @@
           </div>
         </div>
 
-        <!-- PDF pages -->
         <div
           v-else-if="numPages"
+          ref="scrollContainer"
           class="pdf-scroll"
+          @scroll="onScroll"
         >
           <div
-            class="pdf-pages"
-            :style="pagesStyle"
+            class="virtual-spacer"
+            :style="{ height: estimatedTotalHeight + 'px' }"
+          />
+          <div
+            class="rendered-pages-container"
+            :style="renderedContainerStyle"
           >
-            <!-- Render all pages -->
-            <VuePdf
-              v-for="p in numPages"
-              :key="p"
-              :src="pdfSrc"
-              :page="p"
-              :rotation="rotation"
-              class="pdf-page"
-            />
+            <div
+              v-if="showDebug"
+              class="debug-info"
+            >
+              <div>Current Page: {{ currentPage }}</div>
+              <div>Rendered Pages: {{ renderedPages.join(", ") }}</div>
+              <div>Loaded Pages: {{ Array.from(loadedPages).join(", ") }}</div>
+              <div>
+                Loading Pages: {{ Array.from(loadingPages).join(", ") }}
+              </div>
+              <div>Scroll Top: {{ scrollTop }}</div>
+              <div>Navigating: {{ navigating }}</div>
+              <div>Mobile: {{ isMobile }}</div>
+            </div>
+
+            <div
+              v-for="pageNum in renderedPages"
+              :key="`page-${pageNum}-${renderKey}`"
+              class="pdf-page-wrapper"
+              :data-page="pageNum"
+            >
+              <div
+                v-if="!loadedPages.has(pageNum)"
+                class="pdf-page-placeholder"
+                :style="getPlaceholderStyle(pageNum)"
+              >
+                <v-progress-circular
+                  v-if="loadingPages.has(pageNum)"
+                  indeterminate
+                  color="primary"
+                  size="32"
+                />
+                <div
+                  v-else
+                  class="d-flex flex-column align-center"
+                >
+                  <v-icon
+                    color="grey-lighten-1"
+                    size="48"
+                  >
+                    mdi-file-pdf-box
+                  </v-icon>
+                  <span class="text-caption mt-2">Page {{ pageNum }}</span>
+                  <v-btn
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                    class="mt-2"
+                    @click="loadPage(pageNum)"
+                  >
+                    Load Page
+                  </v-btn>
+                </div>
+              </div>
+
+              <VuePdf
+                v-else
+                :key="`pdf-${pageNum}-${zoom}-${rotation}`"
+                :src="pdfSrc"
+                :page="pageNum"
+                :rotation="rotation"
+                :scale="zoom"
+                class="pdf-page"
+                @loaded="onPageLoaded(pageNum, $event)"
+                @error="onPageError(pageNum, $event)"
+              />
+            </div>
           </div>
         </div>
 
@@ -163,7 +310,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { useDisplay } from 'vuetify'
 import { VuePdf, createLoadingTask } from 'vue3-pdfjs/esm'
 import type { PDFDocumentProxy } from 'pdfjs-dist/types/src/display/api'
 
@@ -172,36 +319,128 @@ const props = defineProps<{
   title?: string
   pdfUrl?: string
   fileName?: string
+  bufferPages?: number
+  pageHeight?: number
+  maxCachedPages?: number
 }>()
 
 const emit = defineEmits<{
   (e: 'update:modelValue', v: boolean): void
 }>()
 
+const { mobile } = useDisplay()
+const isMobile = computed(() => mobile.value)
+const BUFFER_PAGES = props.bufferPages || 2
+const DEFAULT_PAGE_HEIGHT = props.pageHeight || 842
+const PAGE_MARGIN = 24
+
 const dialog = computed({
   get: () => props.modelValue,
   set: v => emit('update:modelValue', v),
 })
 
+// State
 const loading = ref(false)
 const error = ref('')
 const downloadLoading = ref(false)
-
+const scrollContainer = ref<HTMLElement>()
+const showDebug = ref(false)
 const pdfSrc = ref<string | Uint8Array | Record<string, unknown>>('')
+const pdfDocument = ref<PDFDocumentProxy | null>(null)
 const numPages = ref(0)
-
+const currentPage = ref(1)
+const pageInput = ref(1)
+const navigating = ref(false)
 const zoom = ref(1)
 const rotation = ref(0)
+const renderKey = ref(0)
+const scrollTop = ref(0)
+const pageHeights = ref<Map<number, number>>(new Map())
+const loadedPages = ref<Set<number>>(new Set())
+const loadingPages = ref<Set<number>>(new Set())
+let scrollTimeout: ReturnType<typeof setTimeout> | null = null
+let navigationTimeout: ReturnType<typeof setTimeout> | null = null
+let resizeObserver: ResizeObserver | null = null
+function setInitialZoom() {
+  zoom.value = isMobile.value ? 0.5 : 1
+  console.log(
+    `Initial zoom set to ${zoom.value * 100}% for ${
+      isMobile.value ? 'mobile' : 'desktop'
+    }`,
+  )
+}
 
-const pagesStyle = computed(() => ({
-  transform: `scale(${zoom.value})`,
-  transformOrigin: 'top left',
+const estimatedPageHeight = computed(() => {
+  const baseHeight = DEFAULT_PAGE_HEIGHT
+  return baseHeight * zoom.value + PAGE_MARGIN * 2
+})
+const estimatedTotalHeight = computed(() => {
+  return numPages.value * estimatedPageHeight.value
+})
+
+const visiblePageRange = computed(() => {
+  if (!numPages.value) return { start: 1, end: 1 }
+  const start = Math.max(1, currentPage.value - BUFFER_PAGES)
+  const end = Math.min(numPages.value, currentPage.value + BUFFER_PAGES)
+  return { start, end }
+})
+
+const renderedPages = computed(() => {
+  const { start, end } = visiblePageRange.value
+  const pages = []
+  for (let i = start; i <= end; i++) {
+    pages.push(i)
+  }
+  return pages
+})
+
+const scrollOffset = computed(() => {
+  if (!renderedPages.value.length) return 0
+
+  const firstRenderedPage = renderedPages.value[0]
+  const offset = Math.max(
+    0,
+    (firstRenderedPage - 1) * estimatedPageHeight.value,
+  )
+
+  return offset
+})
+
+const renderedContainerStyle = computed(() => ({
+  position: 'absolute',
+  top: `${scrollOffset.value}px`,
+  left: '0',
+  right: '0',
+  padding: `${PAGE_MARGIN}px`,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: `${PAGE_MARGIN}px`,
+  zIndex: 2,
+  minHeight: '100px',
 }))
+
+const currentPageFromScroll = computed(() => {
+  if (scrollTop.value === 0) return 1
+
+  const page = Math.floor(scrollTop.value / estimatedPageHeight.value) + 1
+  return Math.min(numPages.value, Math.max(1, page))
+})
 
 watch(
   () => dialog.value,
   async (open) => {
-    if (open && props.pdfUrl) await loadPdf(props.pdfUrl)
+    if (open && props.pdfUrl) {
+      setInitialZoom()
+      await loadPdf(props.pdfUrl)
+      await nextTick()
+      setupResizeObserver()
+      await loadInitialPages()
+    }
+    else {
+      cleanupResizeObserver()
+      clearTimeouts()
+    }
   },
   { immediate: true },
 )
@@ -209,25 +448,106 @@ watch(
 watch(
   () => props.pdfUrl,
   async (u) => {
-    if (dialog.value && u) await loadPdf(u)
+    if (dialog.value && u) {
+      await loadPdf(u)
+      await loadInitialPages()
+    }
     else {
       clearState()
     }
   },
 )
 
+watch(currentPageFromScroll, (newPage) => {
+  if (navigating.value) return
+
+  if (scrollTimeout) {
+    clearTimeout(scrollTimeout)
+  }
+
+  scrollTimeout = setTimeout(() => {
+    if (!navigating.value) {
+      currentPage.value = newPage
+      resetPageInput()
+    }
+  }, 100)
+})
+
+watch(
+  renderedPages,
+  (newPages) => {
+    console.log('Rendered pages changed:', newPages)
+    newPages.forEach((pageNum) => {
+      if (!loadedPages.value.has(pageNum) && !loadingPages.value.has(pageNum)) {
+        loadPage(pageNum)
+      }
+    })
+  },
+  { immediate: true },
+)
+
+watch([zoom, rotation], () => {
+  renderKey.value++
+  // Reload visible pages
+  nextTick(() => {
+    renderedPages.value.forEach((pageNum) => {
+      if (loadedPages.value.has(pageNum)) {
+        // Page will re-render due to renderKey change
+      }
+    })
+  })
+})
+
+function clearTimeouts() {
+  if (scrollTimeout) {
+    clearTimeout(scrollTimeout)
+    scrollTimeout = null
+  }
+  if (navigationTimeout) {
+    clearTimeout(navigationTimeout)
+    navigationTimeout = null
+  }
+}
+
+function setupResizeObserver() {
+  if (typeof window !== 'undefined' && 'ResizeObserver' in window) {
+    resizeObserver = new ResizeObserver(() => {})
+
+    if (scrollContainer.value) {
+      resizeObserver.observe(scrollContainer.value)
+    }
+  }
+}
+
+function cleanupResizeObserver() {
+  if (resizeObserver) {
+    resizeObserver.disconnect()
+    resizeObserver = null
+  }
+}
+
 function clearState() {
   loading.value = false
   error.value = ''
   numPages.value = 0
   pdfSrc.value = ''
-  zoom.value = 1
+  pdfDocument.value = null
   rotation.value = 0
+  currentPage.value = 1
+  pageInput.value = 1
+  scrollTop.value = 0
+  navigating.value = false
+  renderKey.value = 0
+  pageHeights.value.clear()
+  loadedPages.value.clear()
+  loadingPages.value.clear()
+  clearTimeouts()
 }
 
 async function loadPdf(url: string) {
   clearState()
   if (!url) return
+
   try {
     loading.value = true
     error.value = ''
@@ -235,10 +555,14 @@ async function loadPdf(url: string) {
 
     const task = createLoadingTask(pdfSrc.value)
     const pdf: PDFDocumentProxy = await task.promise
+    pdfDocument.value = pdf
     numPages.value = pdf.numPages
+    currentPage.value = 1
+    pageInput.value = 1
+    console.log(`PDF loaded with ${numPages.value} pages`)
   }
   catch (_e) {
-    console.error(_e)
+    console.error('PDF loading error:', _e)
     error.value = 'Failed to load PDF.'
   }
   finally {
@@ -246,12 +570,168 @@ async function loadPdf(url: string) {
   }
 }
 
+async function loadInitialPages() {
+  console.log('Loading initial pages...')
+  await nextTick()
+  if (numPages.value > 0) {
+    await loadPage(1)
+  }
+}
+
+function onScroll() {
+  if (scrollContainer.value && !navigating.value) {
+    scrollTop.value = scrollContainer.value.scrollTop
+  }
+}
+
+async function loadPage(pageNum: number): Promise<boolean> {
+  if (pageNum < 1 || pageNum > numPages.value) {
+    console.warn(`Invalid page number: ${pageNum}`)
+    return false
+  }
+
+  if (loadingPages.value.has(pageNum) || loadedPages.value.has(pageNum)) {
+    console.log(`Page ${pageNum} already loaded or loading`)
+    return loadedPages.value.has(pageNum)
+  }
+
+  console.log(`Loading page ${pageNum}...`)
+  loadingPages.value.add(pageNum)
+
+  try {
+    // Add a small delay to ensure the component is ready
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    // Mark as loaded - the VuePdf component will handle the actual rendering
+    loadedPages.value.add(pageNum)
+
+    console.log(
+      `Page ${pageNum} marked as loaded. Total loaded: ${loadedPages.value.size}`,
+    )
+
+    return true
+  }
+  catch (error) {
+    console.error(`Error loading page ${pageNum}:`, error)
+    loadedPages.value.delete(pageNum)
+    return false
+  }
+  finally {
+    loadingPages.value.delete(pageNum)
+  }
+}
+
+async function goToPage(page: number) {
+  if (page < 1 || page > numPages.value || !scrollContainer.value) {
+    console.warn(`Invalid navigation to page ${page}`)
+    return
+  }
+
+  console.log(`Navigating to page ${page}...`)
+  navigating.value = true
+
+  try {
+    // Clear any existing timeouts
+    clearTimeouts()
+
+    // Update current page immediately
+    currentPage.value = page
+    resetPageInput()
+
+    // Ensure target page is loaded
+    await loadPage(page)
+
+    // Force a re-render to ensure the pages are visible
+    await nextTick()
+
+    // Calculate target position
+    const targetPosition = Math.max(0, (page - 1) * estimatedPageHeight.value)
+
+    // Scroll to position
+    scrollContainer.value.scrollTo({
+      top: targetPosition,
+      behavior: 'smooth',
+    })
+
+    console.log(`Scrolled to position ${targetPosition} for page ${page}`)
+
+    // Reset navigating flag after scroll completes
+    navigationTimeout = setTimeout(() => {
+      navigating.value = false
+      console.log(`Navigation to page ${page} completed`)
+    }, 700)
+  }
+  catch (error) {
+    console.error('Navigation error:', error)
+    navigating.value = false
+  }
+}
+
+function goToPreviousPage() {
+  if (currentPage.value > 1) {
+    goToPage(currentPage.value - 1)
+  }
+}
+
+function goToNextPage() {
+  if (currentPage.value < numPages.value) {
+    goToPage(currentPage.value + 1)
+  }
+}
+
+function goToPageInput() {
+  const targetPage = pageInput.value
+  if (targetPage >= 1 && targetPage <= numPages.value) {
+    goToPage(targetPage)
+  }
+  else {
+    resetPageInput()
+  }
+}
+
+function resetPageInput() {
+  pageInput.value = currentPage.value
+}
+
+function getPlaceholderStyle(pageNum: number) {
+  const pageHeight = pageHeights.value.get(pageNum) || DEFAULT_PAGE_HEIGHT
+  const scaledHeight = pageHeight * zoom.value
+
+  return {
+    width: `${Math.round(scaledHeight * 0.707)}px`,
+    height: `${scaledHeight}px`,
+    backgroundColor: '#f8f9fa',
+    border: '2px dashed #dee2e6',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '8px',
+    boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+  }
+}
+
+function onPageLoaded(pageNum: number, event) {
+  console.log(`VuePdf page ${pageNum} loaded successfully`, event)
+  if (event && event.height) {
+    pageHeights.value.set(pageNum, event.height)
+  }
+}
+
+function onPageError(pageNum: number, error) {
+  console.error(`VuePdf page ${pageNum} error:`, error)
+  loadedPages.value.delete(pageNum)
+  loadingPages.value.delete(pageNum)
+}
+
 function zoomIn() {
-  zoom.value = Math.min(zoom.value + 0.1, 3)
+  zoom.value = Math.min(zoom.value + 0.25, 3)
 }
+
 function zoomOut() {
-  zoom.value = Math.max(zoom.value - 0.1, 0.3)
+  zoom.value = Math.max(zoom.value - 0.25, 0.25)
 }
+
 function rotate() {
   rotation.value = (rotation.value + 90) % 360
 }
@@ -280,7 +760,15 @@ async function downloadPdf() {
   }
 }
 
-onBeforeUnmount(() => {})
+onMounted(async () => {
+  setInitialZoom()
+})
+
+onBeforeUnmount(() => {
+  cleanupResizeObserver()
+  clearTimeouts()
+  clearState()
+})
 </script>
 
 <style scoped>
@@ -288,23 +776,142 @@ onBeforeUnmount(() => {})
   width: 100%;
   height: calc(100vh - 64px);
   overflow: auto;
-  background: #1212120a;
+  background: #f8f9fa;
+  position: relative;
 }
 
-.pdf-pages {
-  padding: 24px;
+.virtual-spacer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.rendered-pages-container {
+  width: 100%;
+}
+
+.pdf-page-wrapper {
+  width: auto;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 0;
 }
 
 .pdf-page {
   display: block;
-  margin: 0 auto 24px auto;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   background: white;
+  border-radius: 4px;
+  max-width: 100%;
+  height: auto;
 }
 
-@media (max-width: 768px) {
+.pdf-page-placeholder {
+  margin: 0 auto;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.page-input :deep(.v-field__input) {
+  text-align: center;
+  font-size: 0.875rem;
+}
+
+.debug-info {
+  position: fixed;
+  top: 100px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.9);
+  color: white;
+  padding: 15px;
+  font-size: 12px;
+  font-family: monospace;
+  border-radius: 4px;
+  z-index: 1000;
+  line-height: 1.4;
+  min-width: 200px;
+}
+
+/* Mobile specific styles */
+@media (max-width: 960px) {
   .pdf-scroll {
     height: calc(100vh - 56px);
+  }
+
+  .toolbar-title {
+    font-size: 1rem;
+  }
+
+  .mobile-title {
+    max-width: 120px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .mobile-nav-group {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+    margin-right: 8px;
+  }
+
+  .mobile-page-info {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    font-size: 0.75rem;
+  }
+
+  .mobile-page-input {
+    width: 45px !important;
+    max-width: 45px !important;
+  }
+
+  .mobile-page-input :deep(.v-field) {
+    font-size: 0.75rem !important;
+    min-height: 32px !important;
+  }
+
+  .mobile-page-input :deep(.v-field__input) {
+    padding: 4px 6px !important;
+    min-height: 24px !important;
+    text-align: center;
+  }
+
+  .mobile-page-total {
+    font-size: 0.75rem;
+    white-space: nowrap;
+    color: rgba(255, 255, 255, 0.87);
+  }
+
+  .mobile-control-group {
+    margin-bottom: 24px;
+  }
+
+  .mobile-control-group h4 {
+    text-align: center;
+    color: rgba(0, 0, 0, 0.87);
+    font-weight: 500;
+  }
+}
+
+/* Extra small screens */
+@media (max-width: 600px) {
+  .mobile-title {
+    max-width: 80px;
+  }
+
+  .mobile-page-input {
+    width: 20px !important;
+    max-width: 20px !important;
+  }
+
+  .mobile-page-total {
+    font-size: 0.7rem;
   }
 }
 </style>

--- a/components/common/PdfPreviewDialog.vue
+++ b/components/common/PdfPreviewDialog.vue
@@ -115,10 +115,8 @@
             </div>
           </div>
           <embed
-            v-else
-            :src="pdfUrl"
-            type="application/pdf"
-            referrerpolicy="strict-origin-when-cross-origin"
+            v-else-if="dataUrl && !loading"
+            :src="dataUrl"
             class="pdf-embed"
             @error="handleEmbedError"
             @load="handleEmbedSuccess"
@@ -174,11 +172,30 @@ const error = ref('')
 const downloadLoading = ref(false)
 const embedBlocked = ref(false)
 
-watch(dialog, (newVal) => {
+const dataUrl = ref('')
+let currentObjectUrl = ''
+
+watch(dialog, async (newVal) => {
   if (newVal && props.pdfUrl) {
     embedBlocked.value = false
+    await convertToBase64(props.pdfUrl)
+  }
+  else {
+    dataUrl.value = ''
   }
 })
+
+watch(
+  () => props.pdfUrl,
+  async (u) => {
+    if (dialog.value && u) {
+      await convertToBase64(u)
+    }
+    else {
+      dataUrl.value = ''
+    }
+  },
+)
 
 const closeDialog = () => {
   dialog.value = false
@@ -213,8 +230,51 @@ const handleEmbedSuccess = () => {
 
 const handleEmbedError = () => {
   embedBlocked.value = true
-  console.warn('PDF embed blocked, likely due to X-Frame-Options restriction')
+  error.value = 'Unable to preview this PDF.'
 }
+
+async function convertToBase64(url) {
+  try {
+    loading.value = true
+    error.value = ''
+    embedBlocked.value = false
+
+    if (currentObjectUrl) {
+      URL.revokeObjectURL(currentObjectUrl)
+      currentObjectUrl = ''
+    }
+
+    const resp = await fetch(url, { mode: 'cors', credentials: 'omit' })
+    if (!resp.ok) throw new Error('HTTP ' + resp.status)
+    const blob = await resp.blob()
+    const pdfBlob
+      = blob.type && blob.type.includes('pdf')
+        ? blob
+        : new Blob([blob], { type: 'application/pdf' })
+    const objectUrl = URL.createObjectURL(pdfBlob)
+    currentObjectUrl = objectUrl
+    dataUrl.value = objectUrl
+  }
+  catch (e) {
+    console.error(e)
+    if (url) {
+      dataUrl.value = url
+      return
+    }
+    error.value = 'Failed to load PDF.'
+    embedBlocked.value = true
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+onBeforeUnmount(() => {
+  if (currentObjectUrl) {
+    URL.revokeObjectURL(currentObjectUrl)
+    currentObjectUrl = ''
+  }
+})
 </script>
 
 <style scoped>

--- a/components/details/preview-gallery.vue
+++ b/components/details/preview-gallery.vue
@@ -113,13 +113,14 @@
         </v-row>
       </div>
     </section>
-
-    <common-pdf-preview-dialog
-      v-model="previewDialog"
-      :title="previewTitle"
-      :pdf-url="previewPdfUrl"
-      :file-name="previewFileName"
-    />
+    <client-only>
+      <common-pdf-preview-dialog
+        v-model="previewDialog"
+        :title="previewTitle"
+        :pdf-url="previewPdfUrl"
+        :file-name="previewFileName"
+      />
+    </client-only>
   </div>
 </template>
 

--- a/components/details/preview-gallery.vue
+++ b/components/details/preview-gallery.vue
@@ -53,17 +53,34 @@
                   v-for="(image, index) in images"
                   :key="index"
                   cover
+                  class="carousel-item-clickable"
+                  @click="handleImageClick(index)"
                 >
-                  <NuxtImg
-                    width="170"
-                    height="auto"
-                    :src="image"
-                    class="carousel-img fill-height"
-                    preload
-                    fetchpriority="high"
-                    alt="Psat Paper Lesson"
-                    format="webp"
-                  />
+                  <div class="carousel-item-content">
+                    <NuxtImg
+                      width="170"
+                      height="auto"
+                      :src="image"
+                      class="carousel-img fill-height"
+                      preload
+                      fetchpriority="high"
+                      alt="Psat Paper Lesson"
+                      format="webp"
+                    />
+                    <div
+                      v-if="showDocPreview"
+                      class="preview-overlay"
+                    >
+                      <v-icon
+                        size="24"
+                        color="white"
+                        class="preview-icon"
+                      >
+                        mdi-eye
+                      </v-icon>
+                      <span class="preview-text">Preview</span>
+                    </div>
+                  </div>
                 </v-carousel-item>
               </v-carousel>
 
@@ -78,15 +95,17 @@
                   :class="{ 'active-box': carouselVal === index }"
                   @click="changeSlide(index)"
                 >
-                  <NuxtImg
-                    width="70px"
-                    height="auto"
-                    :src="image"
-                    placeholder
-                    class="thumbnail-preview"
-                    alt="Psat Paper Lesson"
-                    format="webp"
-                  />
+                  <div class="thumbnail-content">
+                    <NuxtImg
+                      width="70px"
+                      height="auto"
+                      :src="image"
+                      placeholder
+                      class="thumbnail-preview"
+                      alt="Psat Paper Lesson"
+                      format="webp"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -94,6 +113,13 @@
         </v-row>
       </div>
     </section>
+
+    <common-pdf-preview-dialog
+      v-model="previewDialog"
+      :title="previewTitle"
+      :pdf-url="previewPdfUrl"
+      :file-name="previewFileName"
+    />
   </div>
 </template>
 
@@ -118,6 +144,19 @@ const props = defineProps({
     type: Number,
     default: 0,
   },
+  showDocPreview: {
+    type: Boolean,
+    default: false,
+  },
+  // New props for PDF preview functionality
+  paperId: {
+    type: [String, Number],
+    default: null,
+  },
+  paperTitle: {
+    type: String,
+    default: '',
+  },
 })
 
 // Reactive state
@@ -132,6 +171,12 @@ const help_link_data = reactive({
 })
 
 const _active_img = ref(1)
+
+// PDF Preview related
+const previewDialog = ref(false)
+const previewPdfUrl = ref('')
+const previewFileName = ref('')
+const previewTitle = ref('')
 
 const items = reactive([
   {
@@ -169,6 +214,32 @@ const items = reactive([
 // Methods
 function changeSlide(index) {
   carouselVal.value = index
+}
+
+async function handleImageClick() {
+  if (!props.paperId) {
+    console.warn('No paper ID provided for PDF preview')
+    return
+  }
+
+  try {
+    const response = await $fetch(
+      `/api/v1/tests/download/${props.paperId}/pdf`,
+    )
+
+    if (response.status === 1 && response.data?.url) {
+      previewPdfUrl.value = response.data.url
+      previewFileName.value = response.data.name || 'document.pdf'
+      previewTitle.value = props.paperTitle || 'PDF Preview'
+      previewDialog.value = true
+    }
+    else {
+      console.error('Unable to load PDF preview')
+    }
+  }
+  catch (err) {
+    console.error('Error loading PDF preview:', err)
+  }
 }
 
 // Watch effects
@@ -297,6 +368,75 @@ watch(
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.carousel-item-clickable {
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.carousel-item-clickable:hover {
+  transform: scale(1.02);
+}
+
+.carousel-item-content {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.preview-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  color: white;
+}
+
+.carousel-item-clickable:hover .preview-overlay {
+  opacity: 1;
+}
+
+.preview-icon {
+  margin-bottom: 8px;
+}
+
+.preview-text {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.thumbnail-content {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.thumbnail-preview-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  cursor: pointer;
+}
+
+.thumbnail-box:hover .thumbnail-preview-overlay {
+  opacity: 1;
 }
 
 @media screen and (max-width: 600px) {

--- a/components/details/preview-gallery.vue
+++ b/components/details/preview-gallery.vue
@@ -114,7 +114,7 @@
       </div>
     </section>
     <client-only>
-      <common-pdf-preview-dialog
+      <LazyCommonPdfPreviewDialog
         v-model="previewDialog"
         :title="previewTitle"
         :pdf-url="previewPdfUrl"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "leaflet.markercluster": "^1.5.3",
         "nuxt": "^3.16.2",
         "nuxt-gtag": "^3.0.2",
+        "pdfjs-dist": "^5.4.54",
         "solana-wallets-vue": "^0.7.1",
         "three": "^0.175.0",
         "three-custom-shader-material": "^6.3.7",
@@ -43,6 +44,7 @@
         "vue-chartjs": "5.3.2",
         "vue-mathjax-next": "^0.0.6",
         "vue3-emoji-picker": "^1.1.8",
+        "vue3-pdfjs": "^0.1.6",
         "vuedraggable": "4.1.0",
         "yup": "^1.6.1"
       },
@@ -4642,6 +4644,191 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.*"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.77.tgz",
+      "integrity": "sha512-N9w2DkEKE1AXGp3q55GBOP6BEoFrqChDiFqJtKViTpQCWNOSVuMz7LkoGehbnpxtidppbsC36P0kCZNqJKs29w==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.77",
+        "@napi-rs/canvas-darwin-arm64": "0.1.77",
+        "@napi-rs/canvas-darwin-x64": "0.1.77",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.77",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.77",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.77",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.77",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.77",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.77",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.77"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.77.tgz",
+      "integrity": "sha512-jC8YX0rbAnu9YrLK1A52KM2HX9EDjrJSCLVuBf9Dsov4IC6GgwMLS2pwL9GFLJnSZBFgdwnA84efBehHT9eshA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.77.tgz",
+      "integrity": "sha512-VFaCaCgAV0+hPwXajDIiHaaGx4fVCuUVYp/CxCGXmTGz699ngIEBx3Sa2oDp0uk3X+6RCRLueb7vD44BKBiPIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.77.tgz",
+      "integrity": "sha512-uD2NSkf6I4S3o0POJDwweK85FE4rfLNA2N714MgiEEMMw5AmupfSJGgpYzcyEXtPzdaca6rBfKcqNvzR1+EyLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.77.tgz",
+      "integrity": "sha512-03GxMMZGhHRQxiA4gyoKT6iQSz8xnA6T9PAfg/WNJnbkVMFZG782DwUJUb39QIZ1uE1euMCPnDgWAJ092MmgJQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.77.tgz",
+      "integrity": "sha512-ZO+d2gRU9JU1Bb7SgJcJ1k9wtRMCpSWjJAJ+2phhu0Lw5As8jYXXXmLKmMTGs1bOya2dBMYDLzwp7KS/S/+aCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.77.tgz",
+      "integrity": "sha512-S1KtnP1+nWs2RApzNkdNf8X4trTLrHaY7FivV61ZRaL8NvuGOkSkKa+gWN2iedIGFEDz6gecpl/JAUSewwFXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.77.tgz",
+      "integrity": "sha512-A4YIKFYUwDtrSzCtdCAO5DYmRqlhCVKHdpq0+dBGPnIEhOQDFkPBTfoTAjO3pjlEnorlfKmNMOH21sKQg2esGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.77.tgz",
+      "integrity": "sha512-Lt6Sef5l0+5O1cSZ8ysO0JI+x+rSrqZyXs5f7+kVkCAOVq8X5WTcDVbvWvEs2aRhrWTp5y25Jf2Bn+3IcNHOuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.77.tgz",
+      "integrity": "sha512-NiNFvC+D+omVeJ3IjYlIbyt/igONSABVe9z0ZZph29epHgZYu4eHwV9osfpRt1BGGOAM8LkFrHk4LBdn2EDymA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.77.tgz",
+      "integrity": "sha512-fP6l0hZiWykyjvpZTS3sI46iib8QEflbPakNoUijtwyxRuOPTTBfzAWZUz5z2vKpJJ/8r305wnZeZ8lhsBHY5A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -18844,6 +19031,13 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dommatrix": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dommatrix/-/dommatrix-1.0.3.tgz",
+      "integrity": "sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww==",
+      "deprecated": "dommatrix is no longer maintained. Please use @thednp/dommatrix.",
+      "license": "MIT"
+    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -26519,6 +26713,18 @@
         "inherits": "^2.0.1"
       }
     },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.54",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.54.tgz",
+      "integrity": "sha512-TBAiTfQw89gU/Z4LW98Vahzd2/LoCFprVGvGbTgFt+QCB1F+woyOPmNNVgLa6djX9Z9GGTnj7qE1UzpOVJiINw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.74"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -32308,6 +32514,37 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/vue3-pdfjs": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/vue3-pdfjs/-/vue3-pdfjs-0.1.6.tgz",
+      "integrity": "sha512-7UaWbsp8wNqB0y/rRlyo5yRb0S+XOkkSpmdUuS267Dhi07Pt4RFEetQ8inrpf/aTFJwGnW0Uc/UE4p376s+Zmw==",
+      "license": "MIT",
+      "dependencies": {
+        "pdfjs-dist": "^2.10.377",
+        "vue": "^3.2.19"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/vue3-pdfjs/node_modules/pdfjs-dist": {
+      "version": "2.16.105",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.16.105.tgz",
+      "integrity": "sha512-J4dn41spsAwUxCpEoVf6GVoz908IAA3mYiLmNxg8J9kfRXc2jxpbUepcP0ocp0alVNLFthTAM8DZ1RaHh8sU0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dommatrix": "^1.0.3",
+        "web-streams-polyfill": "^3.2.1"
+      },
+      "peerDependencies": {
+        "worker-loader": "^3.0.8"
+      },
+      "peerDependenciesMeta": {
+        "worker-loader": {
+          "optional": true
+        }
       }
     },
     "node_modules/vuedraggable": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "leaflet.markercluster": "^1.5.3",
     "nuxt": "^3.16.2",
     "nuxt-gtag": "^3.0.2",
+    "pdfjs-dist": "^5.4.54",
     "solana-wallets-vue": "^0.7.1",
     "three": "^0.175.0",
     "three-custom-shader-material": "^6.3.7",
@@ -54,6 +55,7 @@
     "vue-chartjs": "5.3.2",
     "vue-mathjax-next": "^0.0.6",
     "vue3-emoji-picker": "^1.1.8",
+    "vue3-pdfjs": "^0.1.6",
     "vuedraggable": "4.1.0",
     "yup": "^1.6.1"
   },

--- a/pages/paper/[id]/[[slug]].vue
+++ b/pages/paper/[id]/[[slug]].vue
@@ -100,6 +100,9 @@
                   :image-urls="previewImages"
                   :help-link-data="galleryHelpData"
                   :initial-slide="1"
+                  :paper-id="contentData?.id"
+                  :paper-title="contentData?.title"
+                  :show-doc-preview="true"
                 />
               </v-col>
               <v-col


### PR DESCRIPTION
Introduces a new PdfPreviewDialog component for in-app PDF viewing and downloading. Integrates PDF preview functionality into the preview-gallery component, enabling users to preview PDFs directly from the gallery when showDocPreview is enabled. Updates the paper page to pass necessary props for PDF preview support.