### PR TITLE
feat: implement progressive loading indicators for download buttons

### DIFF
--- a/components/paper/detail/ContentInfo.vue
+++ b/components/paper/detail/ContentInfo.vue
@@ -102,57 +102,85 @@
       >
         <div v-if="contentData?.files?.word.exist">
           <v-btn
-            class="mb-2 text-h5"
+            class="mb-2 text-h5 position-relative"
             block
             size="large"
             variant="flat"
             color="primary"
-            :loading="qWordFileDownloadLoading"
-
+            :loading="qWordFileDownloadLoading && !isDownloading('q_word')"
             @click="handleDownloadClick('q_word')"
           >
+            <template v-if="isDownloading('q_word')">
+              <v-progress-circular
+                :model-value="getDownloadProgress('q_word')"
+                size="24"
+                width="3"
+                color="white"
+                class="position-absolute"
+                style="z-index: 2;"
+              />
+            </template>
             <v-icon
               size="x-large"
               class="btn-icon"
+              :class="{ 'text-transparent': isDownloading('q_word') }"
             >
               mdi-file-word-box
             </v-icon>
-            {{ getButtonText('Download Question Doc') }}
+            <span :class="{ 'text-transparent': isDownloading('q_word') }">
+              {{ getButtonText('Download Question Doc') }}
+            </span>
             <template v-if="requiresCoinPaymentForFile('q_word') && contentData?.files?.word.price === 0">
               <v-icon
                 size="small"
                 color="orange"
+                :class="{ 'text-transparent': isDownloading('q_word') }"
               >
                 mdi-coin
               </v-icon>
             </template>
             <template v-else-if="contentData?.files?.word.price > 0">
-              | ${{ contentData?.files?.word.price }}
+              <span :class="{ 'text-transparent': isDownloading('q_word') }">
+                | ${{ contentData?.files?.word.price }}
+              </span>
             </template>
           </v-btn>
         </div>
         <div v-if="contentData?.files.pdf.exist">
           <v-btn
-            class="mb-2 text-h5 text-white font-weight-bold"
+            class="mb-2 text-h5 text-white font-weight-bold position-relative"
             block
             variant="flat"
             size="large"
             color="#E60012"
-            :loading="qPdfFileDownloadLoading"
-
+            :loading="qPdfFileDownloadLoading && !isDownloading('q_pdf')"
             @click="handleDownloadClick('q_pdf')"
           >
+            <template v-if="isDownloading('q_pdf')">
+              <v-progress-circular
+                :model-value="getDownloadProgress('q_pdf')"
+                size="24"
+                width="3"
+                color="white"
+                class="position-absolute"
+                style="z-index: 2;"
+              />
+            </template>
             <v-icon
               size="x-large"
               class="btn-icon"
+              :class="{ 'text-transparent': isDownloading('q_pdf') }"
             >
               mdi-file-pdf-box
             </v-icon>
-            {{ getButtonText('Download Question Paper') }}
+            <span :class="{ 'text-transparent': isDownloading('q_pdf') }">
+              {{ getButtonText('Download Question Paper') }}
+            </span>
             <template v-if="requiresCoinPaymentForFile('q_pdf') && contentData?.files?.pdf.price === 0">
               <v-icon
                 size="small"
                 color="orange"
+                :class="{ 'text-transparent': isDownloading('q_pdf') }"
               >
                 mdi-coin
               </v-icon>
@@ -165,60 +193,92 @@
         <div v-if="contentData?.files.answer.exist">
           <v-btn
             v-show="contentData?.files.answer.ext == 'pdf'"
-            class="mb-2 text-h5 font-weight-bold"
+            class="mb-2 text-h5 font-weight-bold position-relative"
             block
             variant="flat"
             size="large"
             color="teal accent-3"
-            :loading="answerFileDownloadLoading"
+            :loading="answerFileDownloadLoading && !isDownloading('a_file')"
             @click="handleDownloadClick('a_file')"
           >
+            <template v-if="isDownloading('a_file')">
+              <v-progress-circular
+                :model-value="getDownloadProgress('a_file')"
+                size="24"
+                width="3"
+                color="white"
+                class="position-absolute"
+                style="z-index: 2;"
+              />
+            </template>
             <v-icon
               size="x-large"
               class="btn-icon"
+              :class="{ 'text-transparent': isDownloading('a_file') }"
             >
               mdi-file-pdf-box
             </v-icon>
-            {{ getButtonText('Download Mark Scheme') }}
+            <span :class="{ 'text-transparent': isDownloading('a_file') }">
+              {{ getButtonText('Download Mark Scheme') }}
+            </span>
             <template v-if="requiresCoinPaymentForFile('a_file') && contentData?.files?.answer.price === 0">
               <v-icon
                 size="small"
                 color="orange"
+                :class="{ 'text-transparent': isDownloading('a_file') }"
               >
                 mdi-coin
               </v-icon>
             </template>
             <template v-else-if="contentData?.files?.answer.price > 0">
-              | ${{ contentData?.files?.answer.price }}
+              <span :class="{ 'text-transparent': isDownloading('a_file') }">
+                | ${{ contentData?.files?.answer.price }}
+              </span>
             </template>
           </v-btn>
           <v-btn
             v-show="contentData?.files.answer.ext == 'word'"
-            class="mb-2 text-h5"
+            class="mb-2 text-h5 position-relative"
             block
             color="primary"
             variant="flat"
             size="large"
-            :loading="answerFileDownloadLoading"
+            :loading="answerFileDownloadLoading && !isDownloading('a_file')"
             @click="handleDownloadClick('a_file')"
           >
+            <template v-if="isDownloading('a_file')">
+              <v-progress-circular
+                :model-value="getDownloadProgress('a_file')"
+                size="24"
+                width="3"
+                color="white"
+                class="position-absolute"
+                style="z-index: 2;"
+              />
+            </template>
             <v-icon
               size="x-large"
               class="btn-icon"
+              :class="{ 'text-transparent': isDownloading('a_file') }"
             >
               mdi-file-word-box
             </v-icon>
-            {{ getButtonText('Download Answer Doc') }}
+            <span :class="{ 'text-transparent': isDownloading('a_file') }">
+              {{ getButtonText('Download Answer Doc') }}
+            </span>
             <template v-if="requiresCoinPaymentForFile('a_file') && contentData?.files?.answer.price === 0">
               <v-icon
                 size="small"
                 color="orange"
+                :class="{ 'text-transparent': isDownloading('a_file') }"
               >
                 mdi-coin
               </v-icon>
             </template>
             <template v-else-if="contentData?.files?.answer.price > 0">
-              | ${{ contentData?.files?.answer.price }}
+              <span :class="{ 'text-transparent': isDownloading('a_file') }">
+                | ${{ contentData?.files?.answer.price }}
+              </span>
             </template>
           </v-btn>
         </div>
@@ -228,18 +288,29 @@
           <v-btn
             v-for="(extra, index) in contentData.files.extra"
             :key="index"
-            class="mb-2 text-h5 font-weight-bold"
+            class="mb-2 text-h5 font-weight-bold position-relative"
             block
             color="blue"
             variant="flat"
             size="large"
-            :loading="extraFileDownloadLoading"
+            :loading="extraFileDownloadLoading && !isDownloading('extra', extra.id)"
             @click="handleDownloadClick('extra', extra.id)"
           >
+            <template v-if="isDownloading('extra', extra.id)">
+              <v-progress-circular
+                :model-value="getDownloadProgress('extra', extra.id)"
+                size="24"
+                width="3"
+                color="white"
+                class="position-absolute"
+                style="z-index: 2;"
+              />
+            </template>
             <template v-if="extra?.ext == 'mp3'">
               <v-icon
                 size="x-large"
                 class="btn-icon"
+                :class="{ 'text-transparent': isDownloading('extra', extra.id) }"
               >
                 mdi-volume-high
               </v-icon>
@@ -248,21 +319,27 @@
               <v-icon
                 size="x-large"
                 class="btn-icon"
+                :class="{ 'text-transparent': isDownloading('extra', extra.id) }"
               >
                 mdi-file-pdf-box
               </v-icon>
             </template>
-            {{ getButtonText(`Download ${extra.type_title ? extra.type_title : "Extra"}`) }}
+            <span :class="{ 'text-transparent': isDownloading('extra', extra.id) }">
+              {{ getButtonText(`Download ${extra.type_title ? extra.type_title : "Extra"}`) }}
+            </span>
             <template v-if="requiresCoinPaymentForFile('extra', extra.id) && extra.price === 0">
               <v-icon
                 size="small"
                 color="orange"
+                :class="{ 'text-transparent': isDownloading('extra', extra.id) }"
               >
                 mdi-coin
               </v-icon>
             </template>
             <template v-else-if="extra.price > 0">
-              | ${{ extra.price }}
+              <span :class="{ 'text-transparent': isDownloading('extra', extra.id) }">
+                | ${{ extra.price }}
+              </span>
             </template>
           </v-btn>
         </div>
@@ -304,6 +381,8 @@
     :answer-file-download-loading="answerFileDownloadLoading"
     :extra-file-download-loading="extraFileDownloadLoading"
     :requires-coin-payment-for-file="requiresCoinPaymentForFile"
+    :is-downloading="isDownloading"
+    :get-download-progress="getDownloadProgress"
     @download="handleDownloadClick"
   />
   <!-- End mobile order section -->
@@ -542,7 +621,27 @@ const openAuthDialog = (val) => {
   router.push({ query: { auth_form: val } })
 }
 
+// Track download progress for each button
+const downloadProgress = ref({})
+const downloadingItems = ref(new Set())
+
+const getDownloadProgress = (type, extraId) => {
+  const downloadKey = extraId ? `${type}-${extraId}` : type
+  return downloadProgress.value[downloadKey] || 0
+}
+
+const isDownloading = (type, extraId) => {
+  const downloadKey = extraId ? `${type}-${extraId}` : type
+  return downloadingItems.value.has(downloadKey)
+}
+
 const startDownload = async (type, extraId) => {
+  const downloadKey = extraId ? `${type}-${extraId}` : type
+
+  // Set loading state and progress tracking
+  downloadingItems.value.add(downloadKey)
+  downloadProgress.value[downloadKey] = 0
+
   let apiUrl = ''
   if (type === 'q_word') {
     apiUrl = `/api/v1/tests/download/${props.contentData?.id}/word`
@@ -558,21 +657,70 @@ const startDownload = async (type, extraId) => {
   }
 
   try {
+    // Simulate progressive loading for API call
+    const progressInterval = setInterval(() => {
+      if (downloadProgress.value[downloadKey] < 50) {
+        downloadProgress.value[downloadKey] += Math.random() * 15
+      }
+    }, 100)
+
     const response = await useApiService.get(apiUrl)
     console.log('Download response:', response.data)
 
-    const FileSaver = await import('file-saver')
+    // Update progress to 60% after API response
+    downloadProgress.value[downloadKey] = 60
+    clearInterval(progressInterval)
 
-    // Use FileSaver.js the same way as other parts of the codebase
-    console.log('Starting download with FileSaver:', response.data.url, response.data.name)
-    FileSaver.saveAs(response.data.url, response.data.name)
+    // Create a custom fetch with progress tracking
+    const xhr = new XMLHttpRequest()
+    xhr.open('GET', response.data.url, true)
+    xhr.responseType = 'blob'
 
-    // Show success message for coin payments
-    if (requiresCoinPaymentForFile(type, extraId) && !checkFileHasPrice(type, extraId)) {
-      $toast.success('Download started! 5 coins deducted from your balance.')
+    xhr.onprogress = (event) => {
+      if (event.lengthComputable) {
+        const percentComplete = 60 + (event.loaded / event.total) * 40
+        downloadProgress.value[downloadKey] = Math.min(percentComplete, 100)
+      }
     }
+
+    xhr.onload = () => {
+      if (xhr.status === 200) {
+        downloadProgress.value[downloadKey] = 100
+
+        // Use file-saver to save the blob
+        import('file-saver').then(({ saveAs }) => {
+          saveAs(xhr.response, response.data.name)
+        })
+
+        // Show success message for coin payments
+        if (requiresCoinPaymentForFile(type, extraId) && !checkFileHasPrice(type, extraId)) {
+          $toast.success('Download started! 5 coins deducted from your balance.')
+        }
+
+        // Clean up after a short delay
+        setTimeout(() => {
+          downloadingItems.value.delete(downloadKey)
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete downloadProgress.value[downloadKey]
+        }, 1000)
+      }
+    }
+
+    xhr.onerror = () => {
+      downloadingItems.value.delete(downloadKey)
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete downloadProgress.value[downloadKey]
+      $toast.error('Download failed. Please try again.')
+    }
+
+    xhr.send()
   }
   catch (err) {
+    // Clean up on error
+    downloadingItems.value.delete(downloadKey)
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete downloadProgress.value[downloadKey]
+
     if (err.response?.status === 401) {
       openAuthDialog('login')
     }
@@ -627,5 +775,20 @@ p {
 .btn-icon {
   position: absolute;
   left: 10px;
+}
+
+.text-transparent {
+  color: transparent !important;
+}
+
+.position-relative {
+  position: relative;
+}
+
+.position-absolute {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 </style>

--- a/components/paper/detail/MobileOrder.vue
+++ b/components/paper/detail/MobileOrder.vue
@@ -10,87 +10,135 @@
             <v-btn
               block
               color="primary"
-              class="mb-2 text-h6"
+              class="mb-2 text-h6 position-relative"
               variant="flat"
-              :loading="qWordFileDownloadLoading"
+              :loading="qWordFileDownloadLoading && !isDownloading('q_word')"
               @click="$emit('download', 'q_word')"
             >
+              <template v-if="isDownloading('q_word')">
+                <v-progress-circular
+                  :model-value="getDownloadProgress('q_word')"
+                  size="20"
+                  width="2"
+                  color="white"
+                  class="position-absolute"
+                  style="z-index: 2;"
+                />
+              </template>
               <v-icon
                 size="x-large"
                 class="btn-icon"
+                :class="{ 'text-transparent': isDownloading('q_word') }"
               >
                 mdi-file-word-box
               </v-icon>
-              Download Question Doc
+              <span :class="{ 'text-transparent': isDownloading('q_word') }">
+                Download Question Doc
+              </span>
               <template v-if="requiresCoinPaymentForFile('q_word') && contentData?.files?.word.price === 0">
                 <v-icon
                   size="small"
                   color="orange"
+                  :class="{ 'text-transparent': isDownloading('q_word') }"
                 >
                   mdi-coin
                 </v-icon>
               </template>
               <template v-else-if="contentData?.files?.word.price > 0">
-                | ${{ contentData?.files?.word.price }}
+                <span :class="{ 'text-transparent': isDownloading('q_word') }">
+                  | ${{ contentData?.files?.word.price }}
+                </span>
               </template>
             </v-btn>
           </div>
           <div v-if="contentData?.files.pdf.exist">
             <v-btn
-              class="mb-2 text-h6 text-white font-weight-bold"
+              class="mb-2 text-h6 text-white font-weight-bold position-relative"
               block
               variant="flat"
               color="#E60012"
-              :loading="qPdfFileDownloadLoading"
+              :loading="qPdfFileDownloadLoading && !isDownloading('q_pdf')"
               @click="$emit('download', 'q_pdf')"
             >
+              <template v-if="isDownloading('q_pdf')">
+                <v-progress-circular
+                  :model-value="getDownloadProgress('q_pdf')"
+                  size="20"
+                  width="2"
+                  color="white"
+                  class="position-absolute"
+                  style="z-index: 2;"
+                />
+              </template>
               <v-icon
                 size="x-large"
                 class="btn-icon"
+                :class="{ 'text-transparent': isDownloading('q_pdf') }"
               >
                 mdi-file-pdf-box
               </v-icon>
-              Download Question Paper
+              <span :class="{ 'text-transparent': isDownloading('q_pdf') }">
+                Download Question Paper
+              </span>
               <template v-if="requiresCoinPaymentForFile('q_pdf') && contentData?.files?.pdf.price === 0">
                 <v-icon
                   size="small"
                   color="orange"
+                  :class="{ 'text-transparent': isDownloading('q_pdf') }"
                 >
                   mdi-coin
                 </v-icon>
               </template>
               <template v-else-if="contentData?.files?.pdf.price > 0">
-                | ${{ contentData?.files?.pdf.price }}
+                <span :class="{ 'text-transparent': isDownloading('q_pdf') }">
+                  | ${{ contentData?.files?.pdf.price }}
+                </span>
               </template>
             </v-btn>
           </div>
           <div v-if="contentData?.files.answer.exist">
             <v-btn
               v-show="contentData?.files.answer.ext == 'pdf'"
-              class="mb-2 text-h6 font-weight-bold"
+              class="mb-2 text-h6 font-weight-bold position-relative"
               variant="flat"
               block
               color="teal accent-3"
-              :loading="answerFileDownloadLoading"
+              :loading="answerFileDownloadLoading && !isDownloading('a_file')"
               @click="$emit('download', 'a_file')"
             >
+              <template v-if="isDownloading('a_file')">
+                <v-progress-circular
+                  :model-value="getDownloadProgress('a_file')"
+                  size="20"
+                  width="2"
+                  color="white"
+                  class="position-absolute"
+                  style="z-index: 2;"
+                />
+              </template>
               <v-icon
                 size="x-large"
                 class="btn-icon"
+                :class="{ 'text-transparent': isDownloading('a_file') }"
               >
                 mdi-file-pdf-box
               </v-icon>
-              Download Mark Scheme
+              <span :class="{ 'text-transparent': isDownloading('a_file') }">
+                Download Mark Scheme
+              </span>
               <template v-if="requiresCoinPaymentForFile('a_file') && contentData?.files?.answer.price === 0">
                 <v-icon
                   size="small"
                   color="orange"
+                  :class="{ 'text-transparent': isDownloading('a_file') }"
                 >
                   mdi-coin
                 </v-icon>
               </template>
               <template v-else-if="contentData?.files?.answer.price > 0">
-                | ${{ contentData?.files?.answer.price }}
+                <span :class="{ 'text-transparent': isDownloading('a_file') }">
+                  | ${{ contentData?.files?.answer.price }}
+                </span>
               </template>
             </v-btn>
             <v-btn
@@ -98,27 +146,43 @@
               block
               variant="flat"
               color="primary"
-              class="mb-2 text-h6"
-              :loading="answerFileDownloadLoading"
+              class="mb-2 text-h6 position-relative"
+              :loading="answerFileDownloadLoading && !isDownloading('a_file')"
               @click="$emit('download', 'a_file')"
             >
+              <template v-if="isDownloading('a_file')">
+                <v-progress-circular
+                  :model-value="getDownloadProgress('a_file')"
+                  size="20"
+                  width="2"
+                  color="white"
+                  class="position-absolute"
+                  style="z-index: 2;"
+                />
+              </template>
               <v-icon
                 size="x-large"
                 class="btn-icon"
+                :class="{ 'text-transparent': isDownloading('a_file') }"
               >
                 mdi-file-word-box
               </v-icon>
-              Download Answer Doc
+              <span :class="{ 'text-transparent': isDownloading('a_file') }">
+                Download Answer Doc
+              </span>
               <template v-if="requiresCoinPaymentForFile('a_file') && contentData?.files?.answer.price === 0">
                 <v-icon
                   size="small"
                   color="orange"
+                  :class="{ 'text-transparent': isDownloading('a_file') }"
                 >
                   mdi-coin
                 </v-icon>
               </template>
               <template v-else-if="contentData?.files?.answer.price > 0">
-                | ${{ contentData?.files?.answer.price }}
+                <span :class="{ 'text-transparent': isDownloading('a_file') }">
+                  | ${{ contentData?.files?.answer.price }}
+                </span>
               </template>
             </v-btn>
           </div>
@@ -132,15 +196,26 @@
               :key="index"
               block
               color="blue"
-              class="mb-2 text-h6 font-weight-bold"
+              class="mb-2 text-h6 font-weight-bold position-relative"
               variant="flat"
-              :loading="extraFileDownloadLoading"
+              :loading="extraFileDownloadLoading && !isDownloading('extra', extra.id)"
               @click="$emit('download', 'extra', extra.id)"
             >
+              <template v-if="isDownloading('extra', extra.id)">
+                <v-progress-circular
+                  :model-value="getDownloadProgress('extra', extra.id)"
+                  size="20"
+                  width="2"
+                  color="white"
+                  class="position-absolute"
+                  style="z-index: 2;"
+                />
+              </template>
               <template v-if="extra?.ext == 'mp3'">
                 <v-icon
                   size="x-large"
                   class="btn-icon"
+                  :class="{ 'text-transparent': isDownloading('extra', extra.id) }"
                 >
                   mdi-volume-high
                 </v-icon>
@@ -149,21 +224,27 @@
                 <v-icon
                   size="x-large"
                   class="btn-icon"
+                  :class="{ 'text-transparent': isDownloading('extra', extra.id) }"
                 >
                   mdi-file-pdf-box
                 </v-icon>
               </template>
-              Download {{ extra.type_title ? extra.type_title : "Extra" }}
+              <span :class="{ 'text-transparent': isDownloading('extra', extra.id) }">
+                Download {{ extra.type_title ? extra.type_title : "Extra" }}
+              </span>
               <template v-if="requiresCoinPaymentForFile('extra', extra.id) && extra.price === 0">
                 <v-icon
                   size="small"
                   color="orange"
+                  :class="{ 'text-transparent': isDownloading('extra', extra.id) }"
                 >
                   mdi-coin
                 </v-icon>
               </template>
               <template v-else-if="extra.price > 0">
-                | ${{ extra.price }}
+                <span :class="{ 'text-transparent': isDownloading('extra', extra.id) }">
+                  | ${{ extra.price }}
+                </span>
               </template>
             </v-btn>
           </div>
@@ -241,6 +322,14 @@ defineProps({
     type: Function,
     default: () => false,
   },
+  isDownloading: {
+    type: Function,
+    default: () => false,
+  },
+  getDownloadProgress: {
+    type: Function,
+    default: () => 0,
+  },
 })
 
 const _emits = defineEmits(['download', 'open-auth'])
@@ -276,5 +365,20 @@ p {
   margin-right: 8px;
   position: absolute;
   left: 10px;
+}
+
+.text-transparent {
+  color: transparent !important;
+}
+
+.position-relative {
+  position: relative;
+}
+
+.position-absolute {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 </style>

--- a/components/subject-directory/paper-table.vue
+++ b/components/subject-directory/paper-table.vue
@@ -49,41 +49,77 @@
         <div class="d-flex flex-wrap justify-center">
           <v-chip
             small
-            class="ma-1 chip-pill"
+            class="ma-1 chip-pill position-relative"
             color="#F04438"
             :disabled="!item.q_file"
             @click="startDownload('q_pdf', item)"
           >
-            qp
+            <template v-if="isDownloading(item, 'q_pdf')">
+              <v-progress-circular
+                :model-value="getDownloadProgress(item, 'q_pdf')"
+                size="20"
+                width="2"
+                color="white"
+                class="position-absolute"
+              />
+            </template>
+            <span :class="{ 'text-transparent': isDownloading(item, 'q_pdf') }">qp</span>
           </v-chip>
           <v-chip
             small
-            class="ma-1 chip-pill"
+            class="ma-1 chip-pill position-relative"
             color="#12B76A"
             :disabled="!item.a_file"
             @click="startDownload('a_file', item)"
           >
-            ms
+            <template v-if="isDownloading(item, 'a_file')">
+              <v-progress-circular
+                :model-value="getDownloadProgress(item, 'a_file')"
+                size="20"
+                width="2"
+                color="white"
+                class="position-absolute"
+              />
+            </template>
+            <span :class="{ 'text-transparent': isDownloading(item, 'a_file') }">ms</span>
           </v-chip>
 
           <v-chip
             small
-            class="ma-1 chip-pill"
+            class="ma-1 chip-pill position-relative"
             color="#F79009"
             :disabled="!item.sf_file"
             @click="startDownload('sf_file', item)"
           >
-            sf
+            <template v-if="isDownloading(item, 'sf_file')">
+              <v-progress-circular
+                :model-value="getDownloadProgress(item, 'sf_file')"
+                size="20"
+                width="2"
+                color="white"
+                class="position-absolute"
+              />
+            </template>
+            <span :class="{ 'text-transparent': isDownloading(item, 'sf_file') }">sf</span>
           </v-chip>
 
           <v-chip
             small
-            class="ma-1 chip-pill"
+            class="ma-1 chip-pill position-relative"
             color="#8F4949"
             :disabled="!item.in_file"
             @click="startDownload('in_file', item)"
           >
-            in
+            <template v-if="isDownloading(item, 'in_file')">
+              <v-progress-circular
+                :model-value="getDownloadProgress(item, 'in_file')"
+                size="20"
+                width="2"
+                color="white"
+                class="position-absolute"
+              />
+            </template>
+            <span :class="{ 'text-transparent': isDownloading(item, 'in_file') }">in</span>
           </v-chip>
         </div>
       </template>
@@ -180,43 +216,79 @@
                 <!-- QP Chip -->
                 <v-chip
                   x-small
-                  class="chip-pill"
+                  class="chip-pill position-relative"
                   color="#F04438"
                   :disabled="!item.q_file"
                   @click="startDownload('q_pdf', item)"
                 >
-                  qp
+                  <template v-if="isDownloading(item, 'q_pdf')">
+                    <v-progress-circular
+                      :model-value="getDownloadProgress(item, 'q_pdf')"
+                      size="16"
+                      width="2"
+                      color="white"
+                      class="position-absolute"
+                    />
+                  </template>
+                  <span :class="{ 'text-transparent': isDownloading(item, 'q_pdf') }">qp</span>
                 </v-chip>
                 <!-- MS Chip -->
                 <v-chip
                   x-small
-                  class="chip-pill"
+                  class="chip-pill position-relative"
                   color="#12B76A"
                   :disabled="!item.a_file"
                   @click="startDownload('a_file', item)"
                 >
-                  ms
+                  <template v-if="isDownloading(item, 'a_file')">
+                    <v-progress-circular
+                      :model-value="getDownloadProgress(item, 'a_file')"
+                      size="16"
+                      width="2"
+                      color="white"
+                      class="position-absolute"
+                    />
+                  </template>
+                  <span :class="{ 'text-transparent': isDownloading(item, 'a_file') }">ms</span>
                 </v-chip>
                 <!-- SF Chip -->
                 <v-chip
                   x-small
-                  class="chip-pill"
+                  class="chip-pill position-relative"
                   color="#F79009"
                   :disabled="!item.sf_file"
                   @click="startDownload('sf_file', item)"
                 >
-                  sf
+                  <template v-if="isDownloading(item, 'sf_file')">
+                    <v-progress-circular
+                      :model-value="getDownloadProgress(item, 'sf_file')"
+                      size="16"
+                      width="2"
+                      color="white"
+                      class="position-absolute"
+                    />
+                  </template>
+                  <span :class="{ 'text-transparent': isDownloading(item, 'sf_file') }">sf</span>
                 </v-chip>
 
                 <!-- IN Chip -->
                 <v-chip
                   x-small
-                  class="chip-pill"
+                  class="chip-pill position-relative"
                   color="#8F4949"
                   :disabled="!item.in_file"
                   @click="startDownload('in_file', item)"
                 >
-                  in
+                  <template v-if="isDownloading(item, 'in_file')">
+                    <v-progress-circular
+                      :model-value="getDownloadProgress(item, 'in_file')"
+                      size="16"
+                      width="2"
+                      color="white"
+                      class="position-absolute"
+                    />
+                  </template>
+                  <span :class="{ 'text-transparent': isDownloading(item, 'in_file') }">in</span>
                 </v-chip>
 
                 <!-- ExamHub Chip -->
@@ -368,7 +440,17 @@ const safeParseArray = (stringList) => {
   }
 }
 
+// Track download progress for each button
+const downloadProgress = ref({})
+const downloadingItems = ref(new Set())
+
 const startDownload = async (type, item) => {
+  const downloadKey = `${item.id}-${type}`
+
+  // Set loading state
+  downloadingItems.value.add(downloadKey)
+  downloadProgress.value[downloadKey] = 0
+
   let apiUrl = ''
   if (type === 'q_word') apiUrl = `/api/v1/tests/download/${item.id}/word`
   if (type === 'q_pdf') apiUrl = `/api/v1/tests/download/${item.id}/pdf`
@@ -379,14 +461,64 @@ const startDownload = async (type, item) => {
     apiUrl = `/api/v1/tests/download/${item.id}/extra/${item.in_file_id}`
 
   try {
+    // Simulate progressive loading for API call
+    const progressInterval = setInterval(() => {
+      if (downloadProgress.value[downloadKey] < 50) {
+        downloadProgress.value[downloadKey] += Math.random() * 15
+      }
+    }, 100)
+
     const response = await $fetch(apiUrl)
+
+    // Update progress to 60% after API response
+    downloadProgress.value[downloadKey] = 60
+    clearInterval(progressInterval)
 
     const proxyUrl = `/api/file-proxy?url=${encodeURIComponent(response.data.url)}`
 
-    const { saveAs } = await import('file-saver')
-    saveAs(proxyUrl, response.data.name)
+    // Create a custom fetch with progress tracking
+    const xhr = new XMLHttpRequest()
+    xhr.open('GET', proxyUrl, true)
+    xhr.responseType = 'blob'
+
+    xhr.onprogress = (event) => {
+      if (event.lengthComputable) {
+        const percentComplete = 60 + (event.loaded / event.total) * 40
+        downloadProgress.value[downloadKey] = Math.min(percentComplete, 100)
+      }
+    }
+
+    xhr.onload = () => {
+      if (xhr.status === 200) {
+        downloadProgress.value[downloadKey] = 100
+
+        // Use file-saver to save the blob
+        import('file-saver').then(({ saveAs }) => {
+          saveAs(xhr.response, response.data.name)
+        })
+        // Clean up after a short delay
+        setTimeout(() => {
+          downloadingItems.value.delete(downloadKey)
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete downloadProgress.value[downloadKey]
+        }, 1000)
+      }
+    }
+
+    xhr.onerror = () => {
+      downloadingItems.value.delete(downloadKey)
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete downloadProgress.value[downloadKey]
+    }
+
+    xhr.send()
   }
   catch (err) {
+    // Clean up on error
+    downloadingItems.value.delete(downloadKey)
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete downloadProgress.value[downloadKey]
+
     if (err.response?.status === 400) {
       if (
         err.response.data?.status === 0
@@ -397,6 +529,16 @@ const startDownload = async (type, item) => {
     }
     console.error(err)
   }
+}
+
+const isDownloading = (item, type) => {
+  const downloadKey = `${item.id}-${type}`
+  return downloadingItems.value.has(downloadKey)
+}
+
+const getDownloadProgress = (item, type) => {
+  const downloadKey = `${item.id}-${type}`
+  return downloadProgress.value[downloadKey] || 0
 }
 
 const lineDetectLoadMorePaperRef = ref(null)
@@ -531,13 +673,15 @@ function getMonthName(monthNumber) {
 
 /* Styling the v-data-table for mobile card view */
 .mobile-card {
-  padding: 12px 16px;
+  padding: 12px 12px;
   width: 100%;
   box-sizing: border-box;
 }
 
 .paper-info {
   margin-bottom: 12px;
+  display: inline-block;
+  margin-inline: 5px;
 }
 
 .paper-info-part {
@@ -550,6 +694,7 @@ function getMonthName(monthNumber) {
 .paper-chips {
   display: flex;
   flex-wrap: wrap;
+  justify-content: space-between;
   gap: 8px;
 }
 
@@ -562,6 +707,24 @@ function getMonthName(monthNumber) {
   align-items: center;
   justify-content: center;
 }
+
+.exam-hub-chip:last-child {
+  flex-grow: 1;
+  justify-content: end;
+  max-width: min-content;
+}
+
+/* .v-chip .v-chip__underlay
+{
+  display: none !important;
+  position: static;
+
+} */
+
+/* :deep(.exam-hub-chip:last-child > .chip__underlay)
+{
+  max-width: fit-content !important;
+} */
 
 .separator {
   height: 2px;
@@ -576,6 +739,21 @@ function getMonthName(monthNumber) {
 }
 .min-width-200 {
   min-width: 300px;
+}
+
+.text-transparent {
+  color: transparent !important;
+}
+
+.position-relative {
+  position: relative;
+}
+
+.position-absolute {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 @media screen and (max-width: 960px) {


### PR DESCRIPTION
## 🚀 Progressive Loading for Download Buttons

Replaces spinning loaders with progressive circular indicators that fill up gradually (0-100%) as downloads complete, providing real-time feedback to users.

### Changes
- **Paper Table**: Progressive loading for all download chips (qp, ms, sf, in)
- **Paper Detail**: Progressive indicators for Word, PDF, Answer, and Extra files
- **Mobile**: Responsive progressive loading for mobile download buttons

### Technical
- Uses XMLHttpRequest to track actual download progress
- Multi-stage progress: API call (0-50%) → Response (60%) → Download (60-100%)
- Visual feedback with transparent text during downloads
- Automatic cleanup after completion

**Breaking Changes:** None
