### PR TITLE
feat: add progress indicator to OTP login verification

### DIFF
--- a/app/components/common/login.vue
+++ b/app/components/common/login.vue
@@ -451,6 +451,12 @@ async function registerV2(identity, pass) {
                   :loading="otp_loading"
                   @finish="onFinish"
                 />
+                <v-progress-linear
+                  v-if="otp_loading"
+                  indeterminate
+                  color="primary"
+                  class="mt-3"
+                />
               </v-col>
               <v-col
                 cols="12"


### PR DESCRIPTION
Add v-progress-linear component to show loading state during OTP verification in the login flow. This provides visual feedback to users while the verification API processes their request.

Fixes #813