### PR TITLE
feat(stripe payment): add stripe payment in modal charge wallet

### DIFF
--- a/app/components/modals/ChargeWallet.vue
+++ b/app/components/modals/ChargeWallet.vue
@@ -58,6 +58,16 @@
 
     <div class="w-100 d-flex flex-column align-center justify-center mt-8">
       <span class="font-weight-bold text-h4">Quick Recharge</span>
+      <span class="font-weight-bold text-h5 text-center mt-2">
+        Paying with {{ paymentMethod === 'stripe' ? 'Stripe' : 'Crypto' }}?
+
+        <span
+          class="cursor-pointer text-primary"
+          @click="togglePayment"
+        >
+          Switch to {{ paymentMethod === 'stripe' ? 'Crypto' : 'Stripe' }}
+        </span>
+      </span>
 
       <span class="primary-gray-500 text-h6 text-center mt-4">Don't have time? Recharge your wallet instantly.Select your pack!</span>
 
@@ -66,129 +76,133 @@
       </span>
     </div>
 
-    <div class="w-100 d-flex align-center justify-center mt-6 recharge-input">
+    <modals-stripe-payment v-if="paymentMethod == 'stripe'" />
+
+    <template v-if="paymentMethod == 'crypto'">
+      <div class="w-100 d-flex align-center justify-center mt-6 recharge-input">
+        <v-btn
+          color="#344054"
+          max-width="40"
+          min-width="40"
+          height="40"
+          rounded="lg"
+          flat
+          :disabled="loadingPayment"
+          @click="decreaseAmount"
+        >
+          <div class="circle-div d-flex align-center justify-center bg-white">
+            <v-icon
+              color="#344054"
+              size="22"
+            >
+              md:remove
+            </v-icon>
+          </div>
+        </v-btn>
+
+        <v-text-field
+          v-model="formattedAmount"
+          class="w-100 mx-4 text-center"
+          variant="outlined"
+          hide-details
+          density="comfortable"
+          rounded="lg"
+          color="#ffb300"
+          :disabled="loadingPayment"
+          @input="onAmountInput"
+        >
+          <template #prepend-inner>
+            <img
+              width="20"
+              height="20"
+              :src="selectedCurrency.logoURI"
+              alt="Coin Logo"
+              class="rounded-circle"
+            >
+          </template>
+        </v-text-field>
+
+        <v-btn
+          color="#344054"
+          max-width="40"
+          min-width="40"
+          height="40"
+          rounded="lg"
+          flat
+          :disabled="loadingPayment"
+          @click="increaseAmount"
+        >
+          <div class="circle-div d-flex align-center justify-center bg-white">
+            <v-icon
+              color="#344054"
+              size="20"
+            >
+              md:add
+            </v-icon>
+          </div>
+        </v-btn>
+      </div>
+
+      <div class="w-100 d-flex justify-center align-center ga-2 mt-6">
+        <v-btn
+          v-for="currency in currencies"
+          :key="currency.name"
+          :color="selectedCurrency.name === currency.name ? 'primary' : 'white'"
+          :class="`text-h5 font-weight-bold ${
+            selectedCurrency.name === currency.name ? `` : `border-btn`
+          }`"
+          rounded="pill"
+          flat
+          width="100"
+          height="38"
+          :disabled="loadingPayment"
+          @click="selectCurrency(currency)"
+        >
+          {{ currency.name }}
+        </v-btn>
+      </div>
+
       <v-btn
-        color="#344054"
-        max-width="40"
-        min-width="40"
-        height="40"
-        rounded="lg"
-        flat
-        :disabled="loadingPayment"
-        @click="decreaseAmount"
-      >
-        <div class="circle-div d-flex align-center justify-center bg-white">
-          <v-icon
-            color="#344054"
-            size="22"
-          >
-            md:remove
-          </v-icon>
-        </div>
-      </v-btn>
-
-      <v-text-field
-        v-model="formattedAmount"
-        class="w-100 mx-4 text-center"
-        variant="outlined"
-        hide-details
-        density="comfortable"
-        rounded="lg"
-        color="#ffb300"
-        :disabled="loadingPayment"
-        @input="onAmountInput"
-      >
-        <template #prepend-inner>
-          <img
-            width="20"
-            height="20"
-            :src="selectedCurrency.logoURI"
-            alt="Coin Logo"
-            class="rounded-circle"
-          >
-        </template>
-      </v-text-field>
-
-      <v-btn
-        color="#344054"
-        max-width="40"
-        min-width="40"
-        height="40"
-        rounded="lg"
-        flat
-        :disabled="loadingPayment"
-        @click="increaseAmount"
-      >
-        <div class="circle-div d-flex align-center justify-center bg-white">
-          <v-icon
-            color="#344054"
-            size="20"
-          >
-            md:add
-          </v-icon>
-        </div>
-      </v-btn>
-    </div>
-
-    <div class="w-100 d-flex justify-center align-center ga-2 mt-6">
-      <v-btn
-        v-for="currency in currencies"
-        :key="currency.name"
-        :color="selectedCurrency.name === currency.name ? 'primary' : 'white'"
-        :class="`text-h5 font-weight-bold ${
-          selectedCurrency.name === currency.name ? `` : `border-btn`
-        }`"
-        rounded="pill"
-        flat
-        width="100"
-        height="38"
-        :disabled="loadingPayment"
-        @click="selectCurrency(currency)"
-      >
-        {{ currency.name }}
-      </v-btn>
-    </div>
-
-    <v-btn
-      v-if="!isWalletConnected"
-      color="primary"
-      flat
-      rounded="lg"
-      max-width="250"
-      min-width="250"
-      class="font-weight-bold text-h5 mt-4 mx-auto"
-      @click="showWalletModal = true"
-    >
-      Connect Wallet
-    </v-btn>
-
-    <div class="w-100 d-flex ga-2 align-center justify-center">
-      <v-btn
-        v-if="isWalletConnected"
-        :loading="loadingPayment"
-        :disabled="disablePayment"
-        color="success"
+        v-if="!isWalletConnected"
+        color="primary"
         flat
         rounded="lg"
-        max-width="200"
-        class="w-50 font-weight-bold text-h5 mt-4 mx-auto"
-        @click="startProccessPayment"
+        max-width="250"
+        min-width="250"
+        class="font-weight-bold text-h5 mt-4 mx-auto"
+        @click="showWalletModal = true"
       >
-        Charge
+        Connect Wallet
       </v-btn>
-      <v-btn
-        v-if="isWalletConnected"
-        color="error"
-        flat
-        variant="outlined"
-        rounded="lg"
-        max-width="200"
-        class="w-50 font-weight-bold text-h5 mt-4 mx-auto"
-        @click="showDisconnectModal = true"
-      >
-        Disconnect
-      </v-btn>
-    </div>
+
+      <div class="w-100 d-flex ga-2 align-center justify-center">
+        <v-btn
+          v-if="isWalletConnected"
+          :loading="loadingPayment"
+          :disabled="disablePayment"
+          color="success"
+          flat
+          rounded="lg"
+          max-width="200"
+          class="w-50 font-weight-bold text-h5 mt-4 mx-auto"
+          @click="startProccessPayment"
+        >
+          Charge
+        </v-btn>
+        <v-btn
+          v-if="isWalletConnected"
+          color="error"
+          flat
+          variant="outlined"
+          rounded="lg"
+          max-width="200"
+          class="w-50 font-weight-bold text-h5 mt-4 mx-auto"
+          @click="showDisconnectModal = true"
+        >
+          Disconnect
+        </v-btn>
+      </div>
+    </template>
 
     <v-dialog
       v-model="showWalletModal"
@@ -262,6 +276,7 @@ import { SystemProgram, Transaction, PublicKey,
 const auth = useAuth()
 const { $toast } = useNuxtApp()
 const router = useRouter()
+const { startPayment, verifyPayment } = usePayment()
 
 defineProps({
   userBalance: {
@@ -270,6 +285,11 @@ defineProps({
   },
 })
 const emit = defineEmits(['chargeWalletSuccessfull'])
+
+const paymentMethod = ref('stripe')
+const togglePayment = () => {
+  paymentMethod.value = paymentMethod.value === 'stripe' ? 'crypto' : 'stripe'
+}
 
 const formatNumber = (value) => {
   if (value === null || value === undefined || value === '') return ''
@@ -526,16 +546,17 @@ const startProccessPayment = async () => {
   if (auth.isAuthenticated.value) {
     try {
       loadingPayment.value = true
-      const params = {
+      const payload = {
         amount: amount.value * 10 ** selectedCurrency.value.decimals,
         currency: selectedCurrency.value.name,
+        gateway: 'GamaTrain',
+        title: 'Gamatrain Usage Invoice',
+        description: 'One-time charge for use of the Gamatrain e-learning platform. Payment grants access to platform features and learning materials.',
       }
-      const responsePayment = await useApiService.post(
-        '/api/v2/payments',
-        params,
-      )
+      const responsePayment = await startPayment(payload)
+
       if (responsePayment.succeeded) {
-        paymentId.value = responsePayment.data
+        paymentId.value = responsePayment.data.paymentId
         await sendTransactionInChain()
       }
       else {
@@ -761,15 +782,7 @@ const sendTransactionInChain = async () => {
 
 const sendConfirmPaymentRequest = async () => {
   try {
-    const params = {
-      id: paymentId.value,
-      transactionId: transactionId.value,
-      currency: selectedCurrency.value.name,
-    }
-    const responsePaymentConfirmed = await useApiService.post(
-      '/api/v2/payments/verify',
-      params,
-    )
+    const responsePaymentConfirmed = await verifyPayment(paymentId.value, transactionId.value)
     if (responsePaymentConfirmed.succeeded) {
       emit('chargeWalletSuccessfull')
       loadingPayment.value = false

--- a/app/components/modals/StripePayment.vue
+++ b/app/components/modals/StripePayment.vue
@@ -1,0 +1,206 @@
+<template>
+  <div class="w-100 d-flex align-center justify-center mt-6 recharge-input">
+    <v-btn
+      color="#344054"
+      max-width="40"
+      min-width="40"
+      height="40"
+      rounded="lg"
+      flat
+      :disabled="loadingPayment"
+      @click="decreaseAmount"
+    >
+      <div class="circle-div d-flex align-center justify-center bg-white">
+        <v-icon
+          color="#344054"
+          size="22"
+        >
+          md:remove
+        </v-icon>
+      </div>
+    </v-btn>
+
+    <v-text-field
+      v-model="formattedAmount"
+      class="w-100 mx-4 text-center"
+      variant="outlined"
+      hide-details
+      density="comfortable"
+      rounded="lg"
+      color="#ffb300"
+      :disabled="loadingPayment"
+      @input="onAmountInput"
+    >
+      <template #prepend-inner>
+        <v-icon
+          size="24"
+          color="#168118"
+        >
+          md:attach_money
+        </v-icon>
+      </template>
+    </v-text-field>
+
+    <v-btn
+      color="#344054"
+      max-width="40"
+      min-width="40"
+      height="40"
+      rounded="lg"
+      flat
+      :disabled="loadingPayment"
+      @click="increaseAmount"
+    >
+      <div class="circle-div d-flex align-center justify-center bg-white">
+        <v-icon
+          color="#344054"
+          size="20"
+        >
+          md:add
+        </v-icon>
+      </div>
+    </v-btn>
+  </div>
+
+  <div class="w-100 d-flex justify-center align-center ga-2 mt-6">
+    <v-btn
+      v-for="i in 3"
+      :key="i"
+      color="white"
+      class="text-h5 font-weight-bold border-solid border-grey700 border-sm"
+      rounded="pill"
+      flat
+      width="100"
+      height="38"
+      :disabled="loadingPayment"
+      @click="select(i)"
+    >
+      <v-icon
+        size="20"
+        color="#168118"
+      >
+        md:attach_money
+      </v-icon>{{ i * 5 }}
+    </v-btn>
+  </div>
+
+  <v-btn
+    color="success"
+    flat
+    rounded="lg"
+    max-width="250"
+    min-width="250"
+    class="font-weight-bold text-white text-h5 mt-4 mx-auto"
+    :loading="loadingPayment"
+    @click="pay"
+  >
+    Pay With Stripe
+  </v-btn>
+</template>
+
+<script setup lang="ts">
+import type { PaymentCurrency, PaymentGateway } from '~/types/api'
+import { usePayment } from '../../composables/api/usePayment'
+
+const route = useRoute()
+const { startPayment, loadingPayment, savePathRedirect } = usePayment()
+
+const step = ref(5)
+const decimals = ref(1)
+const currency: PaymentCurrency = 'USDC'
+const gateway: PaymentGateway = 'Stripe'
+const amount = ref<number>(5)
+const formattedAmount = ref<string>('5')
+
+const formatNumber = (value: string | number): string => {
+  if (value === null || value === undefined || value === '') return ''
+
+  const num = typeof value === 'number' ? value.toString() : value
+  if (isNaN(Number(num))) return num
+
+  const [intPart, decPart] = num.split('.')
+
+  const formattedInt = intPart?.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+
+  return decPart ? `${formattedInt}.${decPart}` : formattedInt ?? ''
+}
+
+const onAmountInput = (event: Event) => {
+  const target = event.target as HTMLInputElement
+  const val = target.value
+
+  let cleanVal = val.replace(/,/g, '')
+
+  if (cleanVal === '.') {
+    formattedAmount.value = '0.'
+    amount.value = 0
+    target.value = formattedAmount.value
+    return
+  }
+
+  if (/^\d+\.$/.test(cleanVal)) {
+    formattedAmount.value = cleanVal
+    amount.value = parseFloat(cleanVal) || 0
+    target.value = formattedAmount.value
+    return
+  }
+
+  if (cleanVal.includes('.')) {
+    const [intPart, decPart = ''] = cleanVal.split('.')
+
+    if (decPart.length > decimals.value) {
+      cleanVal = intPart + '.' + decPart.slice(0, decimals.value)
+    }
+  }
+
+  if (!/^\d*\.?\d*$/.test(cleanVal)) return
+
+  const numeric = parseFloat(cleanVal)
+  amount.value = isNaN(numeric) ? 0 : numeric
+
+  formattedAmount.value = formatNumber(cleanVal)
+  target.value = formattedAmount.value
+}
+
+const increaseAmount = () => {
+  amount.value = parseFloat(
+    (amount.value + step.value).toFixed(decimals.value),
+  )
+  formattedAmount.value = formatNumber(amount.value)
+}
+
+const decreaseAmount = () => {
+  amount.value = Math.max(
+    0,
+    parseFloat(
+      (amount.value - step.value).toFixed(decimals.value),
+    ),
+  )
+  formattedAmount.value = formatNumber(amount.value)
+}
+
+const select = (multiplier: number) => {
+  amount.value = parseFloat(
+    (multiplier * step.value).toFixed(decimals.value),
+  )
+  formattedAmount.value = formatNumber(amount.value)
+}
+
+const pay = async () => {
+  const payload = {
+    amount: amount.value,
+    currency,
+    gateway,
+    title: 'Gamatrain Usage Invoice',
+    description: 'One-time charge for use of the Gamatrain e-learning platform. Payment grants access to platform features and learning materials.',
+  }
+  const response = await startPayment(payload)
+  if (response.succeeded && response.data && response.data.url) {
+    savePathRedirect(route.fullPath)
+    window.location.href = response.data.url
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/app/composables/api/usePayment.ts
+++ b/app/composables/api/usePayment.ts
@@ -1,0 +1,89 @@
+import type {
+  ApiResult,
+  AppError,
+  PayloadPaymentDTO,
+  PaymentDTO,
+} from '~/types/api'
+
+const KEY = 'redirect_after_payment'
+const loadingPayment = ref(false)
+const loadingVerifyPayment = ref(false)
+
+export const usePayment = () => {
+  const { $toast } = useNuxtApp()
+
+  const startPayment = async (payload: PayloadPaymentDTO) => {
+    try {
+      loadingPayment.value = true
+      const response = await useApiService.post<
+        ApiResult<PaymentDTO>
+      >(
+        '/api/v2/payments',
+        { ...payload },
+      )
+      if (!response.succeeded) {
+        $toast.error('The operation failed. Please try again later.')
+      }
+
+      return response
+    }
+    catch (err: unknown) {
+      const error = err as AppError
+      if (error.response?.status === 400) {
+        $toast.error(error.response.data?.message || '')
+      }
+      return {
+        succeeded: false,
+        data: undefined,
+        message: 'The operation failed. Please try again later.',
+      }
+    }
+    finally {
+      loadingPayment.value = false
+    }
+  }
+
+  const verifyPayment = async (id: string, transactionId: string) => {
+    try {
+      loadingVerifyPayment.value = true
+      const response = await useApiService.post<
+        ApiResult<boolean>
+      >(
+        `/api/v2/payments/${id}/verify`,
+        {
+          transactionId: transactionId,
+        },
+      )
+      return response
+    }
+    catch (err: unknown) {
+      const error = err as AppError
+      if (error.response?.status === 400) {
+        $toast.error(error.response.data?.message || '')
+      }
+      return {
+        succeeded: false,
+        data: undefined,
+        message: 'The operation failed. Please try again later.',
+      }
+    }
+    finally {
+      loadingVerifyPayment.value = false
+    }
+  }
+
+  const savePathRedirect = (path: string) => {
+    localStorage.setItem(KEY, path)
+  }
+
+  const getPathRedirect = () => {
+    const val = localStorage.getItem(KEY)
+    return val
+  }
+
+  const removePathRedirect = () => {
+    localStorage.removeItem(KEY)
+  }
+
+  return { startPayment, loadingPayment, savePathRedirect, getPathRedirect, removePathRedirect, verifyPayment, loadingVerifyPayment }
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -48,7 +48,7 @@ const route = useRoute()
 const { isOnline } = useNetwork()
 
 const excludedPaths = ['/', '/search', '/school']
-const excludedNames = ['exam-start-id', 'school-add', 'subject-directory', 'governance', 'donate']
+const excludedNames = ['exam-start-id', 'school-add', 'subject-directory', 'governance', 'donate', 'payments-id-verify']
 
 const showBlogSlider = computed(() => {
   return !excludedPaths.includes(route.path) && !excludedNames.includes(route.name)

--- a/app/pages/payments/[id]/verify.vue
+++ b/app/pages/payments/[id]/verify.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="w-100 h-screen d-flex flex-column align-center justify-center">
+    <div
+      v-if="status === 'loading'"
+      class="text-center"
+    >
+      <v-progress-circular
+        color="primary"
+        indeterminate
+        size="64"
+        width="6"
+      />
+      <p class="mt-4 text-h4 text-grey700 font-weight-bold">
+        Checking your payment...
+      </p>
+    </div>
+
+    <div
+      v-else-if="status === 'success'"
+      class="text-center"
+    >
+      <v-icon
+        color="success"
+        size="64"
+      >
+        md:check_circle_outlined
+      </v-icon>
+      <p class="mt-4 text-h4 text-success font-weight-bold">
+        Payment Successful
+      </p>
+      <p class="mt-2 text-h5 text-grey700 font-weight-medium">
+        Your wallet has been charged successfully.
+      </p>
+    </div>
+
+    <div
+      v-else
+      class="text-center"
+    >
+      <v-icon
+        color="error"
+        size="64"
+      >
+        md:error_outlined
+      </v-icon>
+      <p class="mt-4 text-h4 text-error font-weight-bold">
+        Payment Failed
+      </p>
+      <p class="mt-2 text-h5 text-grey700 font-weight-medium">
+        Something went wrong. Please try again.
+      </p>
+    </div>
+
+    <v-btn
+      class="mt-6 font-weight-bold text-h5"
+      color="primary"
+      rounded="pill"
+      flat
+      width="250"
+      @click="goBack"
+    >
+      Return To App
+    </v-btn>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRoute, useRouter } from 'vue-router'
+
+type Status = 'loading' | 'success' | 'error'
+
+const route = useRoute()
+const router = useRouter()
+const { verifyPayment, getPathRedirect, removePathRedirect } = usePayment()
+
+const status = ref<Status>('loading')
+
+const paymentId = route.params.id as string
+const transactionId = route.query.transactionId as string
+
+const verify = async () => {
+  const response = await verifyPayment(paymentId, transactionId)
+  if (response.succeeded && response.data) {
+    status.value = 'success'
+  }
+  else {
+    status.value = 'error'
+  }
+}
+
+const goBack = () => {
+  const redirect = getPathRedirect()
+
+  if (redirect) {
+    removePathRedirect()
+    router.push(redirect)
+  }
+  else {
+    router.push('/user')
+  }
+}
+
+onMounted(async () => {
+  await verify()
+})
+</script>
+
+<style scoped>
+</style>

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -506,3 +506,18 @@ export interface AdminCultureDTO {
   code: string
   displayName: string
 }
+
+export type PaymentCurrency = 'SOL' | 'USDC'
+export type PaymentGateway = 'GamaTrain' | 'Stripe'
+
+export interface PayloadPaymentDTO {
+  amount: number
+  currency: PaymentCurrency
+  gateway: PaymentGateway
+  title: string
+  description: string
+}
+export interface PaymentDTO {
+  paymentId: number
+  url: string
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -241,6 +241,7 @@ export default defineNuxtConfig({
     '/test-maker/**': { ssr: false, prerender: true },
     '/user/**': { ssr: false },
     '/admin/**': { ssr: false },
+    '/payments/**': { ssr: false },
   },
   // Development server configuration
   devServer: {


### PR DESCRIPTION
add component stripe payment and change charge wallet into two mode stripe and crypto and default is stripe, 
add use payment composable for handle request in one place,
add verify page for back from stripe page and handle three mode success error loading and add types in ts,
ssr false for verify page and set to not show blog container in verify page

Fixes #894 

- [ ] New feature