### PR TITLE
feat(tutorial): add structured data (JSON-LD) to tutorial pages

### DIFF
--- a/app/composables/useSeoEngine.ts
+++ b/app/composables/useSeoEngine.ts
@@ -1,0 +1,218 @@
+export type SchemaNode = Record<string, unknown> | null | undefined
+
+export type SchemaContext<TDto = unknown> = {
+  dto: TDto
+  url: string
+  title: string
+  description: string
+  image?: string
+  lang?: string
+}
+
+export interface BreadCrumb {
+  text: string
+  disabled: boolean
+  href: string
+}
+
+export function useSeoSchema() {
+  const SITE_URL = 'https://gamatrain.com'
+  const LOGO = `${SITE_URL}/android-chrome-512x512-light.png`
+  const NAME = 'GamaTrain'
+
+  /**
+   * ---------------------------
+   * Organization
+   * ---------------------------
+   */
+  const organizationSchema = {
+    '@type': 'Organization',
+    '@id': `${SITE_URL}/#organization`,
+    'name': NAME,
+    'url': SITE_URL,
+    'logo': {
+      '@type': 'ImageObject',
+      'url': LOGO,
+    },
+  }
+
+  /**
+   * ---------------------------
+   * WebPage
+   * ---------------------------
+   */
+  const createWebPageSchema = (ctx: SchemaContext) => ({
+    '@type': 'WebPage',
+    '@id': `${ctx.url}#webpage`,
+    'url': ctx.url,
+    'name': ctx.title,
+
+    'isPartOf': {
+      '@id': `${SITE_URL}/#website`,
+    },
+
+    'publisher': {
+      '@id': `${SITE_URL}/#organization`,
+    },
+
+    'about': {
+      '@id': `${ctx.url}#primary`,
+    },
+  })
+
+  /**
+   * ---------------------------
+   * Article Schema
+   * ---------------------------
+   */
+  const createArticleSchema = <TDto>(dto: TDto, ctx: SchemaContext<TDto>) => {
+    const image
+      = (dto as Record<string, unknown>)?.lesson_pic
+        || (dto as Record<string, unknown>)?.thumb_pic
+        || LOGO
+
+    const up_date = (dto as Record<string, unknown>)?.up_date as
+      | string
+      | undefined
+
+    return {
+      '@type': 'Article',
+      '@id': `${ctx.url}#article`,
+      'headline': ctx.title,
+      'description': ctx.description,
+      'image': [image],
+
+      'mainEntityOfPage': {
+        '@type': 'WebPage',
+        '@id': ctx.url,
+      },
+
+      'publisher': {
+        '@type': 'Organization',
+        '@id': `${SITE_URL}/#organization`,
+      },
+
+      'datePublished': up_date ? new Date(up_date).toISOString() : undefined,
+
+      'dateModified': up_date ? new Date(up_date).toISOString() : undefined,
+    }
+  }
+
+  /**
+   * ---------------------------
+   * LearningResource
+   * ---------------------------
+   */
+  const createLearningResourceSchema = <TDto>(
+    dto: TDto,
+    ctx: SchemaContext<TDto>,
+  ) => {
+    const content = (dto as Record<string, unknown>)?.content as
+      | string
+      | undefined
+
+    return {
+      '@type': 'LearningResource',
+      '@id': `${ctx.url}#learning-resource`,
+      'name': ctx.title,
+      'url': ctx.url,
+      'description': ctx.description,
+
+      'educationalUse': 'Instruction',
+      'learningResourceType': 'Lesson',
+
+      'teaches': ctx.title,
+
+      'body': content ? String(content).slice(0, 300) : undefined,
+
+      'mainEntityOfPage': {
+        '@type': 'WebPage',
+        '@id': `${ctx.url}#webpage`,
+      },
+    }
+  }
+
+  /**
+   * ---------------------------
+   * Breadcrumb Schema
+   * ---------------------------
+   */
+  const createBreadcrumbSchema = (
+    items: BreadCrumb[] | undefined,
+    baseUrl: string,
+  ) => {
+    if (!items?.length) return null
+
+    return {
+      '@type': 'BreadcrumbList',
+      'itemListElement': items.map((item, index) => ({
+        '@type': 'ListItem',
+        'position': index + 1,
+        'name': item.text,
+        'item': `${baseUrl}${item.href}`,
+      })),
+    }
+  }
+
+  /**
+   * ---------------------------
+   * SAFE GRAPH BUILDER
+   * ---------------------------
+   */
+  const buildGraph = (...schemas: SchemaNode[]) => {
+    return {
+      '@context': 'https://schema.org',
+      '@graph': schemas.filter(Boolean),
+    }
+  }
+
+  /**
+   * ---------------------------
+   * AUTO SCHEMA ENGINE
+   * ---------------------------
+   */
+  const buildSchema = <TDto>(options: {
+    dto: TDto
+    url: string
+    title: string
+    description: string
+    breadcrumbs?: BreadCrumb[]
+    types: Array<'article' | 'webpage' | 'learning' | 'breadcrumb'>
+  }) => {
+    const ctx: SchemaContext<TDto> = {
+      dto: options.dto,
+      url: options.url,
+      title: options.title,
+      description: options.description,
+    }
+
+    const schemas: SchemaNode[] = [organizationSchema] // Organization schema as default
+
+    if (options.types.includes('webpage')) {
+      schemas.push(createWebPageSchema(ctx))
+    }
+
+    if (options.types.includes('article')) {
+      schemas.push(createArticleSchema(options.dto, ctx))
+    }
+
+    if (options.types.includes('learning')) {
+      schemas.push(createLearningResourceSchema(options.dto, ctx))
+    }
+
+    if (options.types.includes('breadcrumb')) {
+      schemas.push(createBreadcrumbSchema(options.breadcrumbs, options.url))
+    }
+
+    return buildGraph(...schemas)
+  }
+
+  return {
+    organizationSchema,
+    createArticleSchema,
+    createWebPageSchema,
+    createLearningResourceSchema,
+    createBreadcrumbSchema,
+    buildSchema,
+  }
+}

--- a/app/pages/tutorial/[id]/[[slug]].vue
+++ b/app/pages/tutorial/[id]/[[slug]].vue
@@ -188,14 +188,13 @@ interface BreadCrumb {
   disabled: boolean
   href: string
 }
-interface SchemaNode {
-  [key: string]: string | object
-}
 
 const { $dayjs, $renderMathInElement, $ensureMathJaxReady } = useNuxtApp()
 const { mdAndUp } = useDisplay()
 const route = useRoute()
 const router = useRouter()
+
+const { buildSchema } = useSeoSchema()
 
 const breads = ref<BreadCrumb[]>([])
 const openCrashReport = ref(false)
@@ -312,26 +311,26 @@ onMounted(() => {
 })
 
 const requestURL = ref(useRequestURL().host)
-const stripHtmlTags = (input: string, length = 1200) => {
-  if (!input) return ''
+// const stripHtmlTags = (input: string, length = 1200) => {
+//   if (!input) return ''
 
-  const sliced = input.slice(0, length)
+//   const sliced = input.slice(0, length)
 
-  const lastClosingTag = sliced.lastIndexOf('>')
+//   const lastClosingTag = sliced.lastIndexOf('>')
 
-  const safeSlice
-    = lastClosingTag !== -1 ? sliced.slice(0, lastClosingTag + 1) : sliced
+//   const safeSlice
+//     = lastClosingTag !== -1 ? sliced.slice(0, lastClosingTag + 1) : sliced
 
-  const text = safeSlice
-    .replace(/<!--[\s\S]*?-->/g, '') // remove comments
-    .replace(/<\/?[^>]+(>|$)/g, '') // remove tags
-    .replace(/&#\d+;/g, '') // remove emojies and icons
-    .replace(/&[a-zA-Z]+;/g, '') // remove entity like &nbsp;
-    .replace(/\s+/g, ' ') // add spaces for better result
-    .trim()
+//   const text = safeSlice
+//     .replace(/<!--[\s\S]*?-->/g, '') // remove comments
+//     .replace(/<\/?[^>]+(>|$)/g, '') // remove tags
+//     .replace(/&#\d+;/g, '') // remove emojies and icons
+//     .replace(/&[a-zA-Z]+;/g, '') // remove entity like &nbsp;
+//     .replace(/\s+/g, ' ') // add spaces for better result
+//     .trim()
 
-  return text + '...'
-}
+//   return text + '...'
+// }
 
 defineOgImageComponent('TutorialDetail', {
   title: contentData.value?.title,
@@ -339,72 +338,26 @@ defineOgImageComponent('TutorialDetail', {
   up_date: contentData.value?.up_date,
 })
 
-const organizationSchema = {
-  '@type': 'Organization',
-  '@id': 'https://gamatrain.com/#organization',
-  name: 'GamaTrain',
-  url: 'https://gamatrain.com',
-  logo: {
-    '@type': 'ImageObject',
-    url: 'https://gamatrain.com/android-chrome-512x512-light.png',
-  },
-}
-const breadcrumbSchema = computed(() => {
-  if (!breads.value.length) return null
-
-  return {
-    '@type': 'BreadcrumbList',
-    'itemListElement': breads.value.map((item, index) => ({
-      '@type': 'ListItem',
-      'position': index + 1,
-      'name': item.text,
-      'item': `https://${requestURL.value}${item.href}`,
-    })),
-  }
-})
-const articleSchema = computed(() => {
+const schema = computed(() => {
   if (!contentData.value) return null
 
-  const {id, title_url, up_date, lesson_pic } = contentData.value
-  const pageUrl = `https://${requestURL.value}/tutorial/${id}/${title_url}`
+  const dto = contentData.value
 
-  const image = lesson_pic || 'https://gamatrain.com/android-chrome-512x512-light.png'
+  const url = `https://${requestURL.value}/tutorial/${dto.id}/${dto.title_url}`
 
-  return {
-    '@type': 'Article',
-    '@id': `${pageUrl}#article`,
-    'headline': pageTitle.value,
-    'description': pageDescribe.value,
-    'image': [image],
-    'mainEntityOfPage': {
-      '@type': 'WebPage',
-      '@id': `${pageUrl}`,
-    },
-    'publisher': {
-      '@type': 'Organization',
-      '@id': 'https://gamatrain.com/#organization',
-    },
-    'dateModified': new Date(up_date).toISOString(),
-    'datePublished': new Date(up_date).toISOString(),
-  }
+  const title = pageTitle.value
+  const description = pageDescribe.value
+
+  return buildSchema({
+    dto,
+    url,
+    title,
+    description,
+    breadcrumbs: breads.value,
+    types: ['article', 'breadcrumb'],
+  })
 })
-const fullSchema = computed(() => {
-  if (!articleSchema.value) return null
 
-  const graph: SchemaNode [] = [
-    organizationSchema,
-    articleSchema.value,
-  ]
-
-  if (breadcrumbSchema.value) {
-    graph.push(breadcrumbSchema.value)
-  }
-
-  return {
-    '@context': 'https://schema.org',
-    '@graph': graph,
-  }
-})
 const setMetaData = () => {
   if (!contentData.value) return
 
@@ -421,11 +374,11 @@ const setMetaData = () => {
 
   pageTitle.value = baseTitle
 
-  pageDescribe.value = `Learn ${ dto.title } with step-by-step explanations and examples from the ${ dto.base_title } ${ dto.section_title } curriculum.`
+  pageDescribe.value = `Learn ${dto.title} with step-by-step explanations and examples from the ${dto.base_title} ${dto.section_title} curriculum.`
 
-  const ogImage =
-    dto.lesson_pic ||
-    'https://gamatrain.com/android-chrome-512x512-light.png'
+  const ogImage
+    = dto.lesson_pic
+      || 'https://gamatrain.com/android-chrome-512x512-light.png'
 
   useHead({
     title: `${pageTitle.value}`,
@@ -462,7 +415,7 @@ const setMetaData = () => {
           `${dto.title} simple guide`,
           `${dto.title} cheatsheet`,
           `${dto.title} definition`,
-        ].join(', ')
+        ].join(', '),
       },
       {
         property: 'og:image',
@@ -495,7 +448,7 @@ const setMetaData = () => {
       {
         key: 'json-ld-schema',
         type: 'application/ld+json',
-        innerHTML: JSON.stringify(fullSchema.value),
+        innerHTML: JSON.stringify(schema.value),
       },
     ],
   })

--- a/app/pages/tutorial/[id]/[[slug]].vue
+++ b/app/pages/tutorial/[id]/[[slug]].vue
@@ -188,6 +188,9 @@ interface BreadCrumb {
   disabled: boolean
   href: string
 }
+interface SchemaNode {
+  [key: string]: string | object
+}
 
 const { $dayjs, $renderMathInElement, $ensureMathJaxReady } = useNuxtApp()
 const { mdAndUp } = useDisplay()
@@ -197,6 +200,8 @@ const router = useRouter()
 const breads = ref<BreadCrumb[]>([])
 const openCrashReport = ref(false)
 const openShare = ref(false)
+const pageDescribe = ref('')
+const pageTitle = ref('')
 const isAdsLoad = ref(false)
 const bookContentRef = ref<HTMLElement | null>(null)
 const showLessonTree = ref(false)
@@ -254,20 +259,20 @@ const initBreadCrumb = () => {
   })
   breads.value.push(
     {
-      // text: contentData.value.section_title,
-      text: 'ُSection title',
+      text: contentData.value.section_title,
+      // text: 'ُSection title',
       disabled: false,
       href: `/search?type=dars&section=${contentData.value.section}`,
     },
     {
-      // text: contentData.value.base_title,
-      text: 'Base title',
+      text: contentData.value.base_title,
+      // text: 'Base title',
       disabled: false,
       href: `/search?type=dars&section=${contentData.value.section}&base=${contentData.value.base}`,
     },
     {
-      // text: contentData.value.lesson_title,
-      text: 'Lesson title',
+      text: contentData.value.lesson_title,
+      // text: 'Lesson title',
       disabled: false,
       href: `/search?type=dars&section=${contentData.value.section}&base=${contentData.value.base}&lesson=${contentData.value.lesson}`,
     },
@@ -333,50 +338,172 @@ defineOgImageComponent('TutorialDetail', {
   views: contentData.value?.views,
   up_date: contentData.value?.up_date,
 })
-useHead({
-  title: `${contentData.value?.title}`,
-  meta: [
-    {
-      name: 'apple-mobile-web-app-title',
-      content: contentData.value?.title || '',
-    },
-    {
-      name: 'og:title',
-      content: contentData.value?.title || '',
-    },
-    {
-      name: 'og:site_name',
-      content: 'GamaTrain',
-    },
-    {
-      name: 'description',
-      content: stripHtmlTags(contentData.value?.content || ''),
-    },
-    {
-      name: 'og:description',
-      content: stripHtmlTags(contentData.value?.content || ''),
-    },
-    {
-      name: 'keywords',
-      content: [
-        `${contentData.value?.title} study guide`,
-        `${contentData.value?.title} easy tutorial`,
-        `${contentData.value?.title} tutorial`,
-        `${contentData.value?.title} for students`,
-        `${contentData.value?.title} note`,
-        `${contentData.value?.title} revision note`,
-        `${contentData.value?.title} simple guide`,
-        `${contentData.value?.title} cheatsheet`,
-        `${contentData.value?.title} definition`,
-      ].join(', ') },
-  ],
-  link: [
-    {
-      rel: 'canonical',
-      href: `https://${requestURL.value}/tutorial/${contentData.value?.id}/${contentData.value?.title_url}`,
-    },
-  ],
+
+const organizationSchema = {
+  '@type': 'Organization',
+  '@id': 'https://gamatrain.com/#organization',
+  name: 'GamaTrain',
+  url: 'https://gamatrain.com',
+  logo: {
+    '@type': 'ImageObject',
+    url: 'https://gamatrain.com/android-chrome-512x512-light.png',
+  },
+}
+const breadcrumbSchema = computed(() => {
+  if (!breads.value.length) return null
+
+  return {
+    '@type': 'BreadcrumbList',
+    'itemListElement': breads.value.map((item, index) => ({
+      '@type': 'ListItem',
+      'position': index + 1,
+      'name': item.text,
+      'item': `https://${requestURL.value}${item.href}`,
+    })),
+  }
 })
+const articleSchema = computed(() => {
+  if (!contentData.value) return null
+
+  const {id, title_url, up_date, lesson_pic } = contentData.value
+  const pageUrl = `https://${requestURL.value}/tutorial/${id}/${title_url}`
+
+  const image = lesson_pic || 'https://gamatrain.com/android-chrome-512x512-light.png'
+
+  return {
+    '@type': 'Article',
+    '@id': `${pageUrl}#article`,
+    'headline': pageTitle.value,
+    'description': pageDescribe.value,
+    'image': [image],
+    'mainEntityOfPage': {
+      '@type': 'WebPage',
+      '@id': `${pageUrl}`,
+    },
+    'publisher': {
+      '@type': 'Organization',
+      '@id': 'https://gamatrain.com/#organization',
+    },
+    'dateModified': new Date(up_date).toISOString(),
+    'datePublished': new Date(up_date).toISOString(),
+  }
+})
+const fullSchema = computed(() => {
+  if (!articleSchema.value) return null
+
+  const graph: SchemaNode [] = [
+    organizationSchema,
+    articleSchema.value,
+  ]
+
+  if (breadcrumbSchema.value) {
+    graph.push(breadcrumbSchema.value)
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': graph,
+  }
+})
+const setMetaData = () => {
+  if (!contentData.value) return
+
+  const dto: TutorialDTO = contentData.value
+
+  // Build title parts safely from DTO
+  const titleParts = [
+    dto.section_title,
+    dto.base_title,
+    dto.title,
+  ].filter(Boolean)
+
+  const baseTitle = titleParts.join(' ')
+
+  pageTitle.value = baseTitle
+
+  pageDescribe.value = `Learn ${ dto.title } with step-by-step explanations and examples from the ${ dto.base_title } ${ dto.section_title } curriculum.`
+
+  const ogImage =
+    dto.lesson_pic ||
+    'https://gamatrain.com/android-chrome-512x512-light.png'
+
+  useHead({
+    title: `${pageTitle.value}`,
+    meta: [
+      {
+        name: 'apple-mobile-web-app-title',
+        content: pageTitle.value,
+      },
+      {
+        name: 'og:title',
+        content: pageTitle.value,
+      },
+      {
+        name: 'og:site_name',
+        content: 'GamaTrain',
+      },
+      {
+        name: 'description',
+        content: pageDescribe.value,
+      },
+      {
+        name: 'og:description',
+        content: pageDescribe.value,
+      },
+      {
+        name: 'keywords',
+        content: [
+          `${dto.title} study guide`,
+          `${dto.title} easy tutorial`,
+          `${dto.title} tutorial`,
+          `${dto.title} for students`,
+          `${dto.title} note`,
+          `${dto.title} revision note`,
+          `${dto.title} simple guide`,
+          `${dto.title} cheatsheet`,
+          `${dto.title} definition`,
+        ].join(', ')
+      },
+      {
+        property: 'og:image',
+        content: ogImage,
+      },
+      {
+        name: 'twitter:card',
+        content: 'summary_large_image',
+      },
+      {
+        name: 'twitter:title',
+        content: pageTitle.value,
+      },
+      {
+        name: 'twitter:description',
+        content: pageDescribe.value,
+      },
+      {
+        name: 'twitter:image',
+        content: ogImage,
+      },
+    ],
+    link: [
+      {
+        rel: 'canonical',
+        href: `https://${requestURL.value}/tutorial/${dto.id}/${dto.title_url}`,
+      },
+    ],
+    script: [
+      {
+        key: 'json-ld-schema',
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify(fullSchema.value),
+      },
+    ],
+  })
+}
+if (contentData.value) {
+  initBreadCrumb()
+  setMetaData()
+}
 </script>
 
 <style>

--- a/app/pages/tutorial/[id]/[[slug]].vue
+++ b/app/pages/tutorial/[id]/[[slug]].vue
@@ -444,13 +444,15 @@ const setMetaData = () => {
         href: `https://${requestURL.value}/tutorial/${dto.id}/${dto.title_url}`,
       },
     ],
-    script: [
-      {
-        key: 'json-ld-schema',
-        type: 'application/ld+json',
-        innerHTML: JSON.stringify(schema.value),
-      },
-    ],
+    script: schema.value
+      ? [
+          {
+            key: 'json-ld-schema',
+            type: 'application/ld+json',
+            innerHTML: JSON.stringify(schema.value),
+          },
+        ]
+      : [],
   })
 }
 if (contentData.value) {

--- a/app/types/toturial/index.ts
+++ b/app/types/toturial/index.ts
@@ -9,20 +9,24 @@ export interface ProAccess {
 }
 
 export interface TutorialDTO {
-  base: string
-  content: string
-  course: string
-  id: string
-  lesson: string
-  proAccess: ProAccess
-  section: string
-  status: string
-  title: string
-  title_url: string
-  topic: string
-  up_date: string
-  update_jalali: string
-  views: string
+  base: string;
+  content: string;
+  course: string;
+  id: string;
+  lesson: string;
+  proAccess: ProAccess;
+  section: string;
+  status: string;
+  title: string;
+  title_url: string;
+  topic: string;
+  up_date: string;
+  update_jalali: string;
+  views: string;
+  lesson_pic?: string;
+  base_title: string;
+  section_title: string;
+  lesson_title: string;
 }
 
 export interface ChapterDTO {

--- a/app/types/toturial/index.ts
+++ b/app/types/toturial/index.ts
@@ -9,24 +9,24 @@ export interface ProAccess {
 }
 
 export interface TutorialDTO {
-  base: string;
-  content: string;
-  course: string;
-  id: string;
-  lesson: string;
-  proAccess: ProAccess;
-  section: string;
-  status: string;
-  title: string;
-  title_url: string;
-  topic: string;
-  up_date: string;
-  update_jalali: string;
-  views: string;
-  lesson_pic?: string;
-  base_title: string;
-  section_title: string;
-  lesson_title: string;
+  base: string
+  content: string
+  course: string
+  id: string
+  lesson: string
+  proAccess: ProAccess
+  section: string
+  status: string
+  title: string
+  title_url: string
+  topic: string
+  up_date: string
+  update_jalali: string
+  views: string
+  lesson_pic?: string
+  base_title: string
+  section_title: string
+  lesson_title: string
 }
 
 export interface ChapterDTO {


### PR DESCRIPTION
## Description

This PR introduces structured data (JSON-LD) support for tutorial pages to improve SEO visibility, search indexing quality, and eligibility for rich results. It also introduces a reusable schema factory composable to standardize structured data generation across the project.

Fixes #949 

## Type of Change

- [x] New feature

## Checklist

- Added JSON-LD structured data to tutorial pages
-  Introduced a global configurable schema factory composable to generate structured data consistently across pages
-  Centralized schema generation using a reusable @graph builder approach
-  Added SSR-safe guards to ensure schema is only injected when valid data is available
-  Standardized entity linking between Article, WebPage, and Organization

## Additional Notes

- Schema generation is now centralized and reusable across all pages via composable factory

- **LearningResource** was intentionally replaced with **Article** for better SEO and structured data support