### PR TITLE
feat(test): add structured data (JSON-LD) to test pages

### DIFF
--- a/app/composables/useSeoEngine.ts
+++ b/app/composables/useSeoEngine.ts
@@ -16,9 +16,9 @@ export interface BreadCrumb {
 }
 
 export function useSeoSchema() {
-  const SITE_URL = 'https://gamatrain.com'
-  const LOGO = `${SITE_URL}/android-chrome-512x512-light.png`
-  const NAME = 'GamaTrain'
+  const SITE_URL = "https://gamatrain.com";
+  const LOGO = `${SITE_URL}/android-chrome-512x512-light.png`;
+  const NAME = "GamaTrain";
 
   /**
    * ---------------------------
@@ -26,15 +26,15 @@ export function useSeoSchema() {
    * ---------------------------
    */
   const organizationSchema = {
-    '@type': 'Organization',
-    '@id': `${SITE_URL}/#organization`,
-    'name': NAME,
-    'url': SITE_URL,
-    'logo': {
-      '@type': 'ImageObject',
-      'url': LOGO,
+    "@type": "Organization",
+    "@id": `${SITE_URL}/#organization`,
+    name: NAME,
+    url: SITE_URL,
+    logo: {
+      "@type": "ImageObject",
+      url: LOGO,
     },
-  }
+  };
 
   /**
    * ---------------------------
@@ -42,23 +42,23 @@ export function useSeoSchema() {
    * ---------------------------
    */
   const createWebPageSchema = (ctx: SchemaContext) => ({
-    '@type': 'WebPage',
-    '@id': `${ctx.url}#webpage`,
-    'url': ctx.url,
-    'name': ctx.title,
+    "@type": "WebPage",
+    "@id": `${ctx.url}#webpage`,
+    url: ctx.url,
+    name: ctx.title,
 
-    'isPartOf': {
-      '@id': `${SITE_URL}/#website`,
+    isPartOf: {
+      "@id": `${SITE_URL}/#website`,
     },
 
-    'publisher': {
-      '@id': `${SITE_URL}/#organization`,
+    publisher: {
+      "@id": `${SITE_URL}/#organization`,
     },
 
-    'about': {
-      '@id': `${ctx.url}#primary`,
+    about: {
+      "@id": `${ctx.url}#primary`,
     },
-  })
+  });
 
   /**
    * ---------------------------
@@ -66,37 +66,37 @@ export function useSeoSchema() {
    * ---------------------------
    */
   const createArticleSchema = <TDto>(dto: TDto, ctx: SchemaContext<TDto>) => {
-    const image
-      = (dto as Record<string, unknown>)?.lesson_pic
-        || (dto as Record<string, unknown>)?.thumb_pic
-        || LOGO
+    const image =
+      (dto as Record<string, unknown>)?.lesson_pic ||
+      (dto as Record<string, unknown>)?.thumb_pic ||
+      LOGO;
 
     const up_date = (dto as Record<string, unknown>)?.up_date as
       | string
-      | undefined
+      | undefined;
 
     return {
-      '@type': 'Article',
-      '@id': `${ctx.url}#article`,
-      'headline': ctx.title,
-      'description': ctx.description,
-      'image': [image],
+      "@type": "Article",
+      "@id": `${ctx.url}#article`,
+      headline: ctx.title,
+      description: ctx.description,
+      image: [image],
 
-      'mainEntityOfPage': {
-        '@type': 'WebPage',
-        '@id': ctx.url,
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": `${ctx.url}`,
       },
 
-      'publisher': {
-        '@type': 'Organization',
-        '@id': `${SITE_URL}/#organization`,
+      publisher: {
+        "@type": "Organization",
+        "@id": `${SITE_URL}/#organization`,
       },
 
-      'datePublished': up_date ? new Date(up_date).toISOString() : undefined,
+      datePublished: up_date ? new Date(up_date).toISOString() : undefined,
 
-      'dateModified': up_date ? new Date(up_date).toISOString() : undefined,
-    }
-  }
+      dateModified: up_date ? new Date(up_date).toISOString() : undefined,
+    };
+  };
 
   /**
    * ---------------------------
@@ -109,28 +109,33 @@ export function useSeoSchema() {
   ) => {
     const content = (dto as Record<string, unknown>)?.content as
       | string
-      | undefined
+      | undefined;
 
     return {
-      '@type': 'LearningResource',
-      '@id': `${ctx.url}#learning-resource`,
-      'name': ctx.title,
-      'url': ctx.url,
-      'description': ctx.description,
+      "@type": "LearningResource",
+      "@id": `${ctx.url}#learning-resource`,
+      name: ctx.title,
+      url: ctx.url,
+      description: ctx.description,
 
-      'educationalUse': 'Instruction',
-      'learningResourceType': 'Lesson',
+      educationalUse: "Instruction",
+      learningResourceType: "Lesson",
 
-      'teaches': ctx.title,
+      teaches: ctx.title,
 
-      'body': content ? String(content).slice(0, 300) : undefined,
+      body: content ? String(content).slice(0, 300) : undefined,
 
-      'mainEntityOfPage': {
-        '@type': 'WebPage',
-        '@id': `${ctx.url}#webpage`,
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": `${ctx.url}`,
       },
-    }
-  }
+
+      publisher: {
+        "@type": "Organization",
+        "@id": `${SITE_URL}/#organization`,
+      },
+    };
+  };
 
   /**
    * ---------------------------
@@ -141,30 +146,85 @@ export function useSeoSchema() {
     items: BreadCrumb[] | undefined,
     baseUrl: string,
   ) => {
-    if (!items?.length) return null
+    if (!items?.length) return null;
 
     return {
-      '@type': 'BreadcrumbList',
-      'itemListElement': items.map((item, index) => ({
-        '@type': 'ListItem',
-        'position': index + 1,
-        'name': item.text,
-        'item': `${baseUrl}${item.href}`,
+      "@type": "BreadcrumbList",
+      itemListElement: items.map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: item.text,
+        item: `${baseUrl}${item.href}`,
       })),
+    };
+  };
+
+  /**
+   * ---------------------------
+   * Quiz Schema
+   * ---------------------------
+   */
+  const createQuizSchema = (dto: unknown, ctx: SchemaContext) => {
+    const data = dto as Record<string, unknown>;
+
+    const question = data.question;
+    if (typeof question !== "string") {
+      return null;
     }
-  }
+
+    const answers = [data.answer_a, data.answer_b, data.answer_c, data.answer_d]
+      .filter((a): a is string => typeof a === "string" && a.length > 0)
+      .map((text, index) => ({
+        "@type": "Answer",
+        position: index + 1,
+        encodingFormat: "text/html",
+        text,
+      }));
+
+    const correctIndex = Number(data.true_answer) - 1;
+    const acceptedAnswer = answers[correctIndex];
+
+    return {
+      "@type": "Quiz",
+      "@id": `${ctx.url}#quiz`,
+      inLanguage: ctx.lang || "en",
+      learningResourceType: "Assessment",
+
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": `${ctx.url}`,
+      },
+
+      publisher: {
+        "@type": "Organization",
+        "@id": `${SITE_URL}/#organization`,
+      },
+
+      hasPart: {
+        "@type": "Question",
+        eduQuestionType: "Multiple choice",
+        learningResourceType: "Practice Problem",
+        encodingFormat: "text/html",
+
+        image: typeof data.q_file === "string" ? data.q_file : undefined,
+        text: question,
+        suggestedAnswer: answers,
+        acceptedAnswer,
+      },
+    };
+  };
 
   /**
    * ---------------------------
    * SAFE GRAPH BUILDER
    * ---------------------------
    */
-  const buildGraph = (...schemas: SchemaNode[]) => {
+  const buildGraph = (...schemas: SchemaNode[]) => {    
     return {
-      '@context': 'https://schema.org',
-      '@graph': schemas.filter(Boolean),
-    }
-  }
+      "@context": "https://schema.org",
+      "@graph": schemas.filter((s): s is Record<string, unknown> => Boolean(s)),
+    };
+  };
 
   /**
    * ---------------------------
@@ -172,40 +232,44 @@ export function useSeoSchema() {
    * ---------------------------
    */
   const buildSchema = <TDto>(options: {
-    dto: TDto
-    url: string
-    title: string
-    description: string
-    breadcrumbs?: BreadCrumb[]
-    types: Array<'article' | 'webpage' | 'learning' | 'breadcrumb'>
+    dto: TDto;
+    url: string;
+    title: string;
+    description: string;
+    breadcrumbs?: BreadCrumb[];
+    types: Array<"article" | "webpage" | "learning" | "breadcrumb" | "quiz">;
   }) => {
     const ctx: SchemaContext<TDto> = {
       dto: options.dto,
       url: options.url,
       title: options.title,
       description: options.description,
+    };    
+
+    const schemas: SchemaNode[] = [organizationSchema]; // Organization schema as default
+
+    if (options.types.includes("webpage")) {
+      schemas.push(createWebPageSchema(ctx));
     }
 
-    const schemas: SchemaNode[] = [organizationSchema] // Organization schema as default
-
-    if (options.types.includes('webpage')) {
-      schemas.push(createWebPageSchema(ctx))
+    if (options.types.includes("article")) {
+      schemas.push(createArticleSchema(options.dto, ctx));
     }
 
-    if (options.types.includes('article')) {
-      schemas.push(createArticleSchema(options.dto, ctx))
+    if (options.types.includes("learning")) {
+      schemas.push(createLearningResourceSchema(options.dto, ctx));
     }
 
-    if (options.types.includes('learning')) {
-      schemas.push(createLearningResourceSchema(options.dto, ctx))
+    if (options.types.includes("breadcrumb")) {
+      schemas.push(createBreadcrumbSchema(options.breadcrumbs, options.url));
     }
 
-    if (options.types.includes('breadcrumb')) {
-      schemas.push(createBreadcrumbSchema(options.breadcrumbs, options.url))
-    }
+    if (options.types.includes("quiz")) {
+      schemas.push(createQuizSchema(options.dto, ctx));
+    }    
 
-    return buildGraph(...schemas)
-  }
+    return buildGraph(...schemas);
+  };
 
   return {
     organizationSchema,
@@ -214,5 +278,5 @@ export function useSeoSchema() {
     createLearningResourceSchema,
     createBreadcrumbSchema,
     buildSchema,
-  }
+  };
 }

--- a/app/composables/useSeoEngine.ts
+++ b/app/composables/useSeoEngine.ts
@@ -16,9 +16,9 @@ export interface BreadCrumb {
 }
 
 export function useSeoSchema() {
-  const SITE_URL = "https://gamatrain.com";
-  const LOGO = `${SITE_URL}/android-chrome-512x512-light.png`;
-  const NAME = "GamaTrain";
+  const SITE_URL = 'https://gamatrain.com'
+  const LOGO = `${SITE_URL}/android-chrome-512x512-light.png`
+  const NAME = 'GamaTrain'
 
   /**
    * ---------------------------
@@ -26,15 +26,15 @@ export function useSeoSchema() {
    * ---------------------------
    */
   const organizationSchema = {
-    "@type": "Organization",
-    "@id": `${SITE_URL}/#organization`,
-    name: NAME,
-    url: SITE_URL,
-    logo: {
-      "@type": "ImageObject",
-      url: LOGO,
+    '@type': 'Organization',
+    '@id': `${SITE_URL}/#organization`,
+    'name': NAME,
+    'url': SITE_URL,
+    'logo': {
+      '@type': 'ImageObject',
+      'url': LOGO,
     },
-  };
+  }
 
   /**
    * ---------------------------
@@ -42,23 +42,23 @@ export function useSeoSchema() {
    * ---------------------------
    */
   const createWebPageSchema = (ctx: SchemaContext) => ({
-    "@type": "WebPage",
-    "@id": `${ctx.url}#webpage`,
-    url: ctx.url,
-    name: ctx.title,
+    '@type': 'WebPage',
+    '@id': `${ctx.url}#webpage`,
+    'url': ctx.url,
+    'name': ctx.title,
 
-    isPartOf: {
-      "@id": `${SITE_URL}/#website`,
+    'isPartOf': {
+      '@id': `${SITE_URL}/#website`,
     },
 
-    publisher: {
-      "@id": `${SITE_URL}/#organization`,
+    'publisher': {
+      '@id': `${SITE_URL}/#organization`,
     },
 
-    about: {
-      "@id": `${ctx.url}#primary`,
+    'about': {
+      '@id': `${ctx.url}#primary`,
     },
-  });
+  })
 
   /**
    * ---------------------------
@@ -66,37 +66,37 @@ export function useSeoSchema() {
    * ---------------------------
    */
   const createArticleSchema = <TDto>(dto: TDto, ctx: SchemaContext<TDto>) => {
-    const image =
-      (dto as Record<string, unknown>)?.lesson_pic ||
-      (dto as Record<string, unknown>)?.thumb_pic ||
-      LOGO;
+    const image
+      = (dto as Record<string, unknown>)?.lesson_pic
+        || (dto as Record<string, unknown>)?.thumb_pic
+        || LOGO
 
     const up_date = (dto as Record<string, unknown>)?.up_date as
       | string
-      | undefined;
+      | undefined
 
     return {
-      "@type": "Article",
-      "@id": `${ctx.url}#article`,
-      headline: ctx.title,
-      description: ctx.description,
-      image: [image],
+      '@type': 'Article',
+      '@id': `${ctx.url}#article`,
+      'headline': ctx.title,
+      'description': ctx.description,
+      'image': [image],
 
-      mainEntityOfPage: {
-        "@type": "WebPage",
-        "@id": `${ctx.url}`,
+      'mainEntityOfPage': {
+        '@type': 'WebPage',
+        '@id': `${ctx.url}`,
       },
 
-      publisher: {
-        "@type": "Organization",
-        "@id": `${SITE_URL}/#organization`,
+      'publisher': {
+        '@type': 'Organization',
+        '@id': `${SITE_URL}/#organization`,
       },
 
-      datePublished: up_date ? new Date(up_date).toISOString() : undefined,
+      'datePublished': up_date ? new Date(up_date).toISOString() : undefined,
 
-      dateModified: up_date ? new Date(up_date).toISOString() : undefined,
-    };
-  };
+      'dateModified': up_date ? new Date(up_date).toISOString() : undefined,
+    }
+  }
 
   /**
    * ---------------------------
@@ -109,33 +109,33 @@ export function useSeoSchema() {
   ) => {
     const content = (dto as Record<string, unknown>)?.content as
       | string
-      | undefined;
+      | undefined
 
     return {
-      "@type": "LearningResource",
-      "@id": `${ctx.url}#learning-resource`,
-      name: ctx.title,
-      url: ctx.url,
-      description: ctx.description,
+      '@type': 'LearningResource',
+      '@id': `${ctx.url}#learning-resource`,
+      'name': ctx.title,
+      'url': ctx.url,
+      'description': ctx.description,
 
-      educationalUse: "Instruction",
-      learningResourceType: "Lesson",
+      'educationalUse': 'Instruction',
+      'learningResourceType': 'Lesson',
 
-      teaches: ctx.title,
+      'teaches': ctx.title,
 
-      body: content ? String(content).slice(0, 300) : undefined,
+      'body': content ? String(content).slice(0, 300) : undefined,
 
-      mainEntityOfPage: {
-        "@type": "WebPage",
-        "@id": `${ctx.url}`,
+      'mainEntityOfPage': {
+        '@type': 'WebPage',
+        '@id': `${ctx.url}`,
       },
 
-      publisher: {
-        "@type": "Organization",
-        "@id": `${SITE_URL}/#organization`,
+      'publisher': {
+        '@type': 'Organization',
+        '@id': `${SITE_URL}/#organization`,
       },
-    };
-  };
+    }
+  }
 
   /**
    * ---------------------------
@@ -146,18 +146,18 @@ export function useSeoSchema() {
     items: BreadCrumb[] | undefined,
     baseUrl: string,
   ) => {
-    if (!items?.length) return null;
+    if (!items?.length) return null
 
     return {
-      "@type": "BreadcrumbList",
-      itemListElement: items.map((item, index) => ({
-        "@type": "ListItem",
-        position: index + 1,
-        name: item.text,
-        item: `${baseUrl}${item.href}`,
+      '@type': 'BreadcrumbList',
+      'itemListElement': items.map((item, index) => ({
+        '@type': 'ListItem',
+        'position': index + 1,
+        'name': item.text,
+        'item': `${baseUrl}${item.href}`,
       })),
-    };
-  };
+    }
+  }
 
   /**
    * ---------------------------
@@ -165,66 +165,66 @@ export function useSeoSchema() {
    * ---------------------------
    */
   const createQuizSchema = (dto: unknown, ctx: SchemaContext) => {
-    const data = dto as Record<string, unknown>;
+    const data = dto as Record<string, unknown>
 
-    const question = data.question;
-    if (typeof question !== "string") {
-      return null;
+    const question = data.question
+    if (typeof question !== 'string') {
+      return null
     }
 
     const answers = [data.answer_a, data.answer_b, data.answer_c, data.answer_d]
-      .filter((a): a is string => typeof a === "string" && a.length > 0)
+      .filter((a): a is string => typeof a === 'string' && a.length > 0)
       .map((text, index) => ({
-        "@type": "Answer",
-        position: index + 1,
-        encodingFormat: "text/html",
+        '@type': 'Answer',
+        'position': index + 1,
+        'encodingFormat': 'text/html',
         text,
-      }));
+      }))
 
-    const correctIndex = Number(data.true_answer) - 1;
-    const acceptedAnswer = answers[correctIndex];
+    const correctIndex = Number(data.true_answer) - 1
+    const acceptedAnswer = answers[correctIndex]
 
     return {
-      "@type": "Quiz",
-      "@id": `${ctx.url}#quiz`,
-      inLanguage: ctx.lang || "en",
-      learningResourceType: "Assessment",
+      '@type': 'Quiz',
+      '@id': `${ctx.url}#quiz`,
+      'inLanguage': ctx.lang || 'en',
+      'learningResourceType': 'Assessment',
 
-      mainEntityOfPage: {
-        "@type": "WebPage",
-        "@id": `${ctx.url}`,
+      'mainEntityOfPage': {
+        '@type': 'WebPage',
+        '@id': `${ctx.url}`,
       },
 
-      publisher: {
-        "@type": "Organization",
-        "@id": `${SITE_URL}/#organization`,
+      'publisher': {
+        '@type': 'Organization',
+        '@id': `${SITE_URL}/#organization`,
       },
 
-      hasPart: {
-        "@type": "Question",
-        eduQuestionType: "Multiple choice",
-        learningResourceType: "Practice Problem",
-        encodingFormat: "text/html",
+      'hasPart': {
+        '@type': 'Question',
+        'eduQuestionType': 'Multiple choice',
+        'learningResourceType': 'Practice Problem',
+        'encodingFormat': 'text/html',
 
-        image: typeof data.q_file === "string" ? data.q_file : undefined,
-        text: question,
-        suggestedAnswer: answers,
+        'image': typeof data.q_file === 'string' ? data.q_file : undefined,
+        'text': question,
+        'suggestedAnswer': answers,
         acceptedAnswer,
       },
-    };
-  };
+    }
+  }
 
   /**
    * ---------------------------
    * SAFE GRAPH BUILDER
    * ---------------------------
    */
-  const buildGraph = (...schemas: SchemaNode[]) => {    
+  const buildGraph = (...schemas: SchemaNode[]) => {
     return {
-      "@context": "https://schema.org",
-      "@graph": schemas.filter((s): s is Record<string, unknown> => Boolean(s)),
-    };
-  };
+      '@context': 'https://schema.org',
+      '@graph': schemas.filter((s): s is Record<string, unknown> => Boolean(s)),
+    }
+  }
 
   /**
    * ---------------------------
@@ -232,44 +232,44 @@ export function useSeoSchema() {
    * ---------------------------
    */
   const buildSchema = <TDto>(options: {
-    dto: TDto;
-    url: string;
-    title: string;
-    description: string;
-    breadcrumbs?: BreadCrumb[];
-    types: Array<"article" | "webpage" | "learning" | "breadcrumb" | "quiz">;
+    dto: TDto
+    url: string
+    title: string
+    description: string
+    breadcrumbs?: BreadCrumb[]
+    types: Array<'article' | 'webpage' | 'learning' | 'breadcrumb' | 'quiz'>
   }) => {
     const ctx: SchemaContext<TDto> = {
       dto: options.dto,
       url: options.url,
       title: options.title,
       description: options.description,
-    };    
-
-    const schemas: SchemaNode[] = [organizationSchema]; // Organization schema as default
-
-    if (options.types.includes("webpage")) {
-      schemas.push(createWebPageSchema(ctx));
     }
 
-    if (options.types.includes("article")) {
-      schemas.push(createArticleSchema(options.dto, ctx));
+    const schemas: SchemaNode[] = [organizationSchema] // Organization schema as default
+
+    if (options.types.includes('webpage')) {
+      schemas.push(createWebPageSchema(ctx))
     }
 
-    if (options.types.includes("learning")) {
-      schemas.push(createLearningResourceSchema(options.dto, ctx));
+    if (options.types.includes('article')) {
+      schemas.push(createArticleSchema(options.dto, ctx))
     }
 
-    if (options.types.includes("breadcrumb")) {
-      schemas.push(createBreadcrumbSchema(options.breadcrumbs, options.url));
+    if (options.types.includes('learning')) {
+      schemas.push(createLearningResourceSchema(options.dto, ctx))
     }
 
-    if (options.types.includes("quiz")) {
-      schemas.push(createQuizSchema(options.dto, ctx));
-    }    
+    if (options.types.includes('breadcrumb')) {
+      schemas.push(createBreadcrumbSchema(options.breadcrumbs, options.url))
+    }
 
-    return buildGraph(...schemas);
-  };
+    if (options.types.includes('quiz')) {
+      schemas.push(createQuizSchema(options.dto, ctx))
+    }
+
+    return buildGraph(...schemas)
+  }
 
   return {
     organizationSchema,
@@ -278,5 +278,5 @@ export function useSeoSchema() {
     createLearningResourceSchema,
     createBreadcrumbSchema,
     buildSchema,
-  };
+  }
 }

--- a/app/pages/test/[id].vue
+++ b/app/pages/test/[id].vue
@@ -70,7 +70,7 @@ const {
   throw createError({ statusCode: 404, statusMessage: 'Page not found' })
 })
 
-function stripHtmlTags(html: string, length?: number) {
+const stripHtmlTags = (html: string, length?: number) => {
   const text = html
     .replace(/<[^>]*>/g, '') // remove HTML
     .replace(/\$/g, '') // remove $ (LaTeX delimiters)

--- a/app/pages/test/[id].vue
+++ b/app/pages/test/[id].vue
@@ -21,7 +21,7 @@
         cols="12"
         class="px-6"
       >
-        <CommonDetailSubjectDirectoryNav :content-data="contentData" />
+        <CommonDetailSubjectDirectoryNav :content-data="contentData || undefined" />
       </v-col>
     </v-row>
 
@@ -43,10 +43,17 @@
   </v-container>
 </template>
 
-<script setup>
-const { $stripHtmlTags, $cleanSubject } = useNuxtApp()
-const route = useRoute()
+<script setup lang="ts">
+import type {ApiResult, QuestionDTO } from '@/types'
+
+const { $cleanSubject } = useNuxtApp()
+const pageDescribe = ref('')
+const pageTitle = ref('')
 const isAdsLoad = ref(false)
+const requestURL = ref(useRequestURL().host)
+const route = useRoute()
+
+const { buildSchema } = useSeoSchema()
 
 const {
   data: contentData,
@@ -55,40 +62,137 @@ const {
 } = await useAsyncData(`exam-test-${route.params.id}`, async () => {
   const res = await useApiService.get(`/api/v1/examTests/${route.params.id}`,
     { full: true },
-  )
+  ) as ApiResult<QuestionDTO>
+  
   if (res.status === 1) {
     return res.data
   }
   throw createError({ statusCode: 404, statusMessage: 'Page not found' })
 })
 
-useHead({
-  titleTemplate: '%s Gamatrain',
-  title:
-      `${$stripHtmlTags(contentData.value?.question, 100)} | ${$cleanSubject(contentData.value?.lesson_title)} Quiz`,
-  meta: [
-    {
-      name: 'apple-mobile-web-app-title',
-      content:
-          `${$stripHtmlTags(contentData.value?.question, 100)} | ${$cleanSubject(contentData.value?.lesson_title)} Quiz`,
-    },
-    {
-      name: 'og:title',
-      content:
-          `${$stripHtmlTags(contentData.value?.question, 100)} | ${$cleanSubject(contentData.value?.lesson_title)} Quiz`,
-    },
-    {
-      name: 'og:site_name',
-      content: 'GamaTrain',
-    },
-    {
-      name: 'description',
-      content: $stripHtmlTags(contentData.value?.question),
-    },
-    {
-      name: 'og:description',
-      content: $stripHtmlTags(contentData.value?.question),
-    },
-  ],
+function stripHtmlTags(html: string, length?: number) {
+  const text = html
+    .replace(/<[^>]*>/g, '')   // remove HTML
+    .replace(/\$/g, '')        // remove $ (LaTeX delimiters)
+    .trim()
+
+  if (!length) return text
+
+  return text.length > length
+    ? text.slice(0, length).trim() + '...'
+    : text
+}
+const normalizedDto = computed(() => {
+  if (!contentData.value) return null
+
+  const dto = contentData.value
+
+  return {
+    ...dto,
+    question: stripHtmlTags(dto.question),
+    answer_a: stripHtmlTags(dto.answer_a),
+    answer_b: stripHtmlTags(dto.answer_b),
+    answer_c: stripHtmlTags(dto.answer_c),
+    answer_d: stripHtmlTags(dto.answer_d),
+  }
 })
+const schema = computed(() => {
+  if (!normalizedDto.value) return null
+
+  const dto = contentData.value
+
+  const url = `https://${requestURL.value}/test/${dto?.id}`
+
+  const title = pageTitle.value
+  const description = pageDescribe.value
+
+  return buildSchema({
+    dto: normalizedDto.value,
+    url,
+    title,
+    description,
+    types: ['quiz'],
+  })
+})
+const setMetaData = () => {
+  if (!contentData.value) return
+
+  const dto: QuestionDTO = contentData.value
+
+  const questionText = stripHtmlTags(dto.question, 30)  
+
+  pageTitle.value =
+    `${questionText} | ${$cleanSubject(dto.lesson_title)} Quiz`
+
+  pageDescribe.value = stripHtmlTags(dto.question, 300)
+
+  const ogImage = dto.q_file && dto.q_file !== '0'
+    ? dto.q_file
+    : 'https://gamatrain.com/android-chrome-512x512-light.png'
+
+  useHead({
+    titleTemplate: '%s Gamatrain',
+    title: `${pageTitle.value}`,
+    meta: [
+      {
+        name: 'apple-mobile-web-app-title',
+        content: pageTitle.value,
+      },
+      {
+        name: 'og:title',
+        content: pageTitle.value,
+      },
+      {
+        name: 'og:site_name',
+        content: 'GamaTrain',
+      },
+      {
+        name: 'description',
+        content: pageDescribe.value,
+      },
+      {
+        name: 'og:description',
+        content: pageDescribe.value,
+      },
+      {
+        property: 'og:image',
+        content: ogImage,
+      },
+      {
+        name: 'twitter:card',
+        content: 'summary_large_image',
+      },
+      {
+        name: 'twitter:title',
+        content: pageTitle.value,
+      },
+      {
+        name: 'twitter:description',
+        content: pageDescribe.value,
+      },
+      {
+        name: 'twitter:image',
+        content: ogImage,
+      },
+    ],
+    link: [
+      {
+        rel: 'canonical',
+        href: `https://${requestURL.value}/test/${dto.id}`,
+      },
+    ],
+    script: schema.value
+      ? [
+        {
+          key: 'json-ld-schema',
+          type: 'application/ld+json',
+          innerHTML: JSON.stringify(schema.value),
+        },
+      ]
+      : [],
+  })
+}
+if (contentData.value) {
+  setMetaData()
+}
 </script>

--- a/app/pages/test/[id].vue
+++ b/app/pages/test/[id].vue
@@ -44,7 +44,7 @@
 </template>
 
 <script setup lang="ts">
-import type {ApiResult, QuestionDTO } from '@/types'
+import type { ApiResult, QuestionDTO } from '@/types'
 
 const { $cleanSubject } = useNuxtApp()
 const pageDescribe = ref('')
@@ -63,7 +63,7 @@ const {
   const res = await useApiService.get(`/api/v1/examTests/${route.params.id}`,
     { full: true },
   ) as ApiResult<QuestionDTO>
-  
+
   if (res.status === 1) {
     return res.data
   }
@@ -72,8 +72,8 @@ const {
 
 function stripHtmlTags(html: string, length?: number) {
   const text = html
-    .replace(/<[^>]*>/g, '')   // remove HTML
-    .replace(/\$/g, '')        // remove $ (LaTeX delimiters)
+    .replace(/<[^>]*>/g, '') // remove HTML
+    .replace(/\$/g, '') // remove $ (LaTeX delimiters)
     .trim()
 
   if (!length) return text
@@ -119,10 +119,10 @@ const setMetaData = () => {
 
   const dto: QuestionDTO = contentData.value
 
-  const questionText = stripHtmlTags(dto.question, 30)  
+  const questionText = stripHtmlTags(dto.question, 30)
 
-  pageTitle.value =
-    `${questionText} | ${$cleanSubject(dto.lesson_title)} Quiz`
+  pageTitle.value
+    = `${questionText} | ${$cleanSubject(dto.lesson_title)} Quiz`
 
   pageDescribe.value = stripHtmlTags(dto.question, 300)
 
@@ -183,12 +183,12 @@ const setMetaData = () => {
     ],
     script: schema.value
       ? [
-        {
-          key: 'json-ld-schema',
-          type: 'application/ld+json',
-          innerHTML: JSON.stringify(schema.value),
-        },
-      ]
+          {
+            key: 'json-ld-schema',
+            type: 'application/ld+json',
+            innerHTML: JSON.stringify(schema.value),
+          },
+        ]
       : [],
   })
 }


### PR DESCRIPTION
## Description

This PR introduces structured data (JSON-LD) support for test pages to improve SEO visibility, search indexing quality, and eligibility for rich results.

Fixes #967 

## Type of Change

- [x] New feature
- [x] Bug fix

## Checklist

- Added JSON-LD structured data to test pages
- Added SSR-safe guards to ensure schema is only injected when valid data is available
- Created a custom `stripHtmlTags` utility with an optional **length** parameter for schema data to support full-length output when needed (like questions and answers in quiz schema)
- Fixed test page title truncation issue: titles now properly display as

>  _truncated title..._

 instead of incorrectly showing 

> _..._

 only

## Additional Notes

#### Schema.org validation result

Validated using https://validator.schema.org/

✔ No errors detected
✔ No warnings detected

<img width="1903" height="1636" alt="image" src="https://github.com/user-attachments/assets/4ace0b53-4f94-4423-9038-77dc3dc2a547" />

