### PR TITLE
feat(schema): replace Article + LearningResource structure with Article schema in tutorial pages

### DIFF
--- a/app/composables/useSeoEngine.ts
+++ b/app/composables/useSeoEngine.ts
@@ -7,6 +7,7 @@ export type SchemaContext<TDto = unknown> = {
   description: string
   image?: string
   lang?: string
+  body?: string
 }
 
 export interface BreadCrumb {
@@ -22,7 +23,7 @@ export function useSeoSchema() {
 
   /**
    * ---------------------------
-   * Organization
+   * Organization Schema
    * ---------------------------
    */
   const organizationSchema = {
@@ -38,10 +39,38 @@ export function useSeoSchema() {
 
   /**
    * ---------------------------
-   * WebPage
+   * WebPage Schema
    * ---------------------------
    */
-  const createWebPageSchema = (ctx: SchemaContext) => ({
+  const ABOUT_MAP = {
+    'article': '#article',
+    'learning': '#learning-resource',
+    'article-learning': '#learning-resource',
+    'quiz': '#quiz',
+    'webpage': '#primary',
+  } as const
+  const TYPE_PRIORITY = [
+    'article-learning',
+    'article',
+    'learning',
+    'quiz',
+    'webpage',
+  ] as const
+
+  const getAboutFragment = (types: string[]) => {
+    for (const type of TYPE_PRIORITY) {
+      if (types.includes(type)) {
+        return ABOUT_MAP[type]
+      }
+    }
+
+    return '#primary'
+  }
+
+  const createWebPageSchema = (
+    ctx: SchemaContext,
+    aboutFragment: string,
+  ) => ({
     '@type': 'WebPage',
     '@id': `${ctx.url}#webpage`,
     'url': ctx.url,
@@ -56,7 +85,7 @@ export function useSeoSchema() {
     },
 
     'about': {
-      '@id': `${ctx.url}#primary`,
+      '@id': `${ctx.url}${aboutFragment}`,
     },
   })
 
@@ -88,26 +117,33 @@ export function useSeoSchema() {
       },
 
       'publisher': {
-        '@type': 'Organization',
         '@id': `${SITE_URL}/#organization`,
       },
 
-      'datePublished': up_date ? new Date(up_date).toISOString() : undefined,
+      'datePublished': up_date || undefined,
 
-      'dateModified': up_date ? new Date(up_date).toISOString() : undefined,
+      'dateModified': up_date || undefined,
     }
   }
 
   /**
    * ---------------------------
-   * LearningResource
+   * LearningResource Schema
    * ---------------------------
    */
   const createLearningResourceSchema = <TDto>(
     dto: TDto,
     ctx: SchemaContext<TDto>,
   ) => {
-    const content = (dto as Record<string, unknown>)?.content as
+    const up_date = (dto as Record<string, unknown>)?.up_date as
+      | string
+      | undefined
+
+    const course = (dto as Record<string, unknown>)?.course as
+      | string
+      | undefined
+
+    const headline = (dto as Record<string, unknown>)?.title as
       | string
       | undefined
 
@@ -118,12 +154,14 @@ export function useSeoSchema() {
       'url': ctx.url,
       'description': ctx.description,
 
+      'body': ctx.body || undefined,
+
       'educationalUse': 'Instruction',
       'learningResourceType': 'Lesson',
-
-      'teaches': ctx.title,
-
-      'body': content ? String(content).slice(0, 300) : undefined,
+      'educationalLevel': course && course !== '0' ? course : undefined,
+      'teaches': headline,
+      'datePublished': up_date || undefined,
+      'inLanguage': ctx.lang || 'en',
 
       'mainEntityOfPage': {
         '@type': 'WebPage',
@@ -131,9 +169,44 @@ export function useSeoSchema() {
       },
 
       'publisher': {
-        '@type': 'Organization',
         '@id': `${SITE_URL}/#organization`,
       },
+    }
+  }
+
+  /**
+   * ---------------------------
+   * Article - LearningResource Schema
+   * ---------------------------
+   */
+  const createArticleLearningResourceSchema = <TDto>(
+    dto: TDto,
+    ctx: SchemaContext<TDto>,
+  ) => {
+    const article = createArticleSchema(dto, ctx)
+    const learning = createLearningResourceSchema(dto, ctx)
+
+    const {
+      '@type': _articleType,
+      '@id': _articleId,
+    } = article
+
+    const {
+      '@type': _learningType,
+      '@id': _learningId,
+      body: _body,
+      mainEntityOfPage: _mainEntityOfPage,
+      publisher: _publisher,
+      ...learningProps
+    } = learning
+
+    return {
+      '@type': ['Article', 'LearningResource'],
+      '@id': `${ctx.url}#learning-resource`,
+
+      'articleBody': learning.body,
+
+      ...learningProps,
     }
   }
 
@@ -196,7 +269,6 @@ export function useSeoSchema() {
       },
 
       'publisher': {
-        '@type': 'Organization',
         '@id': `${SITE_URL}/#organization`,
       },
 
@@ -236,20 +308,31 @@ export function useSeoSchema() {
     url: string
     title: string
     description: string
+    body?: string
     breadcrumbs?: BreadCrumb[]
-    types: Array<'article' | 'webpage' | 'learning' | 'breadcrumb' | 'quiz'>
+    types: Array<
+      | 'webpage'
+      | 'article'
+      | 'learning'
+      | 'article-learning'
+      | 'breadcrumb'
+      | 'quiz'
+    >
   }) => {
     const ctx: SchemaContext<TDto> = {
       dto: options.dto,
       url: options.url,
       title: options.title,
       description: options.description,
+      body: options.body,
     }
 
     const schemas: SchemaNode[] = [organizationSchema] // Organization schema as default
 
+    const aboutFragment = getAboutFragment(options.types)
+
     if (options.types.includes('webpage')) {
-      schemas.push(createWebPageSchema(ctx))
+      schemas.push(createWebPageSchema(ctx, aboutFragment))
     }
 
     if (options.types.includes('article')) {
@@ -258,6 +341,10 @@ export function useSeoSchema() {
 
     if (options.types.includes('learning')) {
       schemas.push(createLearningResourceSchema(options.dto, ctx))
+    }
+
+    if (options.types.includes('article-learning')) {
+      schemas.push(createArticleLearningResourceSchema(options.dto, ctx))
     }
 
     if (options.types.includes('breadcrumb')) {

--- a/app/pages/test/[id].vue
+++ b/app/pages/test/[id].vue
@@ -70,13 +70,17 @@ const {
   throw createError({ statusCode: 404, statusMessage: 'Page not found' })
 })
 
-const stripHtmlTags = (html: string, length?: number) => {
-  const text = html
-    .replace(/<[^>]*>/g, '') // remove HTML
-    .replace(/\$/g, '') // remove $ (LaTeX delimiters)
-    .trim()
+const stripHtmlTags = (input: string, length = 1200) => {
+  if (!input) return ''
 
-  if (!length) return text
+  const text = input
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<\/?[^>]+(>|$)/g, '')
+    .replace(/&#\d+;/g, '')
+    .replace(/&[a-zA-Z]+;/g, '')
+    .replace(/\$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
 
   return text.length > length
     ? text.slice(0, length).trim() + '...'

--- a/app/pages/tutorial/[id]/[[slug]].vue
+++ b/app/pages/tutorial/[id]/[[slug]].vue
@@ -311,26 +311,22 @@ onMounted(() => {
 })
 
 const requestURL = ref(useRequestURL().host)
-// const stripHtmlTags = (input: string, length = 1200) => {
-//   if (!input) return ''
+const stripHtmlTags = (input: string, length = 1200) => {
+  if (!input) return ''
 
-//   const sliced = input.slice(0, length)
+  const text = input
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<\/?[^>]+(>|$)/g, '')
+    .replace(/&#\d+;/g, '')
+    .replace(/&[a-zA-Z]+;/g, '')
+    .replace(/\$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
 
-//   const lastClosingTag = sliced.lastIndexOf('>')
-
-//   const safeSlice
-//     = lastClosingTag !== -1 ? sliced.slice(0, lastClosingTag + 1) : sliced
-
-//   const text = safeSlice
-//     .replace(/<!--[\s\S]*?-->/g, '') // remove comments
-//     .replace(/<\/?[^>]+(>|$)/g, '') // remove tags
-//     .replace(/&#\d+;/g, '') // remove emojies and icons
-//     .replace(/&[a-zA-Z]+;/g, '') // remove entity like &nbsp;
-//     .replace(/\s+/g, ' ') // add spaces for better result
-//     .trim()
-
-//   return text + '...'
-// }
+  return text.length > length
+    ? text.slice(0, length).trim() + '...'
+    : text
+}
 
 defineOgImageComponent('TutorialDetail', {
   title: contentData.value?.title,
@@ -348,13 +344,16 @@ const schema = computed(() => {
   const title = pageTitle.value
   const description = pageDescribe.value
 
+  const body = stripHtmlTags(dto.content, 150)
+
   return buildSchema({
     dto,
     url,
     title,
     description,
+    body,
     breadcrumbs: breads.value,
-    types: ['article', 'breadcrumb'],
+    types: ['webpage', 'article-learning', 'breadcrumb'],
   })
 })
 


### PR DESCRIPTION
## Description

This PR is a follow-up to the previously merged PR #995 and addresses the reopened issue #949 regarding schema.org implementation for tutorial pages.

The previous implementation used **Article** only, which was later updated based on SEO compatibility requirements.

## Type of Change

- [x] New feature

## Checklist

- Updated SEO engine (`useSeoEngine.ts`) to support mixed schema types (Article + LearningResource) for consistent structured data handling across pages.
- Updated schema to use:
`"@type": ["Article", "LearningResource"]`
- Added LearningResource properties for richer educational metadata:
_learningResourceType_
_educationalUse_
_educationalLevel_
_teaches_

- Ensured all required schema attributes are correctly mapped and consistent

## 🔗 References
Previous PR: #995 
Issue: #949 

## Additional Notes

Updated **body** → **articleBody** based on schema validation requirements, resolving structured data errors and ensuring compliance with schema.org Article specification.
> ❌ Schema validation error:
"The property body is not recognized by the schema (e.g. schema.org) for an object of type Article."



#### Schema.org validation result
Validated using https://validator.schema.org/

✔ No errors detected
✔ No warnings detected
<img width="1903" height="911" alt="image" src="https://github.com/user-attachments/assets/4120cc1e-10eb-4fef-9d5c-8a1255f72cd7" />
