### PR TITLE
fix(title): increase max title length for test pages

### DIFF
--- a/app/pages/test/[id].vue
+++ b/app/pages/test/[id].vue
@@ -123,7 +123,7 @@ const setMetaData = () => {
 
   const dto: QuestionDTO = contentData.value
 
-  const questionText = stripHtmlTags(dto.question, 30)
+  const questionText = stripHtmlTags(dto.question, 130)
 
   pageTitle.value
     = `${questionText} | ${$cleanSubject(dto.lesson_title)} Quiz`


### PR DESCRIPTION
## Description

This PR increases the maximum character limit for page titles on test pages to 130 characters.

Fixes #996 

## Type of Change

- [x] Bug fix


