### PR TITLE
fix(papers): paper preview image alt

### DIFF
--- a/app/components/common/detail/PreviewActionCard.vue
+++ b/app/components/common/detail/PreviewActionCard.vue
@@ -48,10 +48,10 @@
       <img
         width="170"
         :src="thumbPic"
+        :alt="alt"
         class="w-100 h-100 main-image-paper"
         preload
         fetchpriority="high"
-        alt="Psat Paper Lesson"
         loading="eager"
       >
 
@@ -83,6 +83,7 @@ interface IPreviewActionCard {
   thumbPic: string
   id: string
   title: string
+  alt: string
   views?: number | string
   score?: string | number
   hasShare?: boolean

--- a/app/composables/useSeoEngine.ts
+++ b/app/composables/useSeoEngine.ts
@@ -95,35 +95,57 @@ export function useSeoSchema() {
    * ---------------------------
    */
   const createArticleSchema = <TDto>(dto: TDto, ctx: SchemaContext<TDto>) => {
+  const url = new URL(ctx.url);
+  const parts = url.pathname.split("/").filter(Boolean);
+  const base = parts.slice(0, 2);
+
+  const articleBasePath = url.origin + "/" + base.join("/");    
+    
     const image
-      = (dto as Record<string, unknown>)?.lesson_pic
-        || (dto as Record<string, unknown>)?.thumb_pic
+    = (dto as Record<string, unknown>)?.thumb_pic
+      || (dto as Record<string, unknown>)?.lesson_pic
         || LOGO
 
     const up_date = (dto as Record<string, unknown>)?.up_date as
       | string
       | undefined
+    
+      const first_name = (dto as Record<string, unknown>)?.first_name as
+        | string
+      | undefined;
+    
+     const last_name = (dto as Record<string, unknown>)?.last_name as
+       | string
+      | undefined;
+    
+    const authorName = [first_name, last_name].filter(Boolean).join(" ");
 
     return {
-      '@type': 'Article',
-      '@id': `${ctx.url}#article`,
-      'headline': ctx.title,
-      'description': ctx.description,
-      'image': [image],
+      "@type": "Article",
+      "@id": `${articleBasePath}#article`,
+      headline: ctx.title,
+      description: ctx.description,
+      image: [image],
 
-      'mainEntityOfPage': {
-        '@type': 'WebPage',
-        '@id': `${ctx.url}`,
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": `${ctx.url}`,
       },
 
-      'publisher': {
-        '@id': `${SITE_URL}/#organization`,
+      ...(authorName && {
+        author: {
+          "@type": "Person",
+          name: authorName,
+        },
+      }),
+
+      publisher: {
+        "@id": `${SITE_URL}/#organization`,
       },
 
-      'datePublished': up_date || undefined,
-
-      'dateModified': up_date || undefined,
-    }
+      datePublished: (up_date && new Date(up_date).toISOString()) || undefined,
+      dateModified: (up_date && new Date(up_date).toISOString()) || undefined,
+    };
   }
 
   /**
@@ -148,30 +170,30 @@ export function useSeoSchema() {
       | undefined
 
     return {
-      '@type': 'LearningResource',
-      '@id': `${ctx.url}#learning-resource`,
-      'name': ctx.title,
-      'url': ctx.url,
-      'description': ctx.description,
+      "@type": "LearningResource",
+      "@id": `${ctx.url}#learning-resource`,
+      name: ctx.title,
+      url: ctx.url,
+      description: ctx.description,
 
-      'body': ctx.body || undefined,
+      body: ctx.body || undefined,
 
-      'educationalUse': 'Instruction',
-      'learningResourceType': 'Lesson',
-      'educationalLevel': course && course !== '0' ? course : undefined,
-      'teaches': headline,
-      'datePublished': up_date || undefined,
-      'inLanguage': ctx.lang || 'en',
+      educationalUse: "Instruction",
+      learningResourceType: "Lesson",
+      educationalLevel: course && course !== "0" ? course : undefined,
+      teaches: headline,
+      datePublished: (up_date && new Date(up_date).toISOString()) || undefined,
+      inLanguage: ctx.lang || "en",
 
-      'mainEntityOfPage': {
-        '@type': 'WebPage',
-        '@id': `${ctx.url}`,
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": `${ctx.url}`,
       },
 
-      'publisher': {
-        '@id': `${SITE_URL}/#organization`,
+      publisher: {
+        "@id": `${SITE_URL}/#organization`,
       },
-    }
+    };
   }
 
   /**
@@ -204,7 +226,7 @@ export function useSeoSchema() {
       '@type': ['Article', 'LearningResource'],
       '@id': `${ctx.url}#learning-resource`,
 
-      'articleBody': learning.body,
+      articleBody: learning.body,
 
       ...learningProps,
     }
@@ -217,17 +239,16 @@ export function useSeoSchema() {
    */
   const createBreadcrumbSchema = (
     items: BreadCrumb[] | undefined,
-    baseUrl: string,
   ) => {
-    if (!items?.length) return null
+    if (!items?.length) return null    
 
     return {
       '@type': 'BreadcrumbList',
-      'itemListElement': items.map((item, index) => ({
+      itemListElement: items.map((item, index) => ({
         '@type': 'ListItem',
-        'position': index + 1,
-        'name': item.text,
-        'item': `${baseUrl}${item.href}`,
+        position: index + 1,
+        name: item.text,
+        item: `${SITE_URL}${item.href}`,
       })),
     }
   }
@@ -249,8 +270,8 @@ export function useSeoSchema() {
       .filter((a): a is string => typeof a === 'string' && a.length > 0)
       .map((text, index) => ({
         '@type': 'Answer',
-        'position': index + 1,
-        'encodingFormat': 'text/html',
+        position: index + 1,
+        encodingFormat: 'text/html',
         text,
       }))
 
@@ -260,27 +281,27 @@ export function useSeoSchema() {
     return {
       '@type': 'Quiz',
       '@id': `${ctx.url}#quiz`,
-      'inLanguage': ctx.lang || 'en',
-      'learningResourceType': 'Assessment',
+      inLanguage: ctx.lang || 'en',
+      learningResourceType: 'Assessment',
 
-      'mainEntityOfPage': {
+      mainEntityOfPage: {
         '@type': 'WebPage',
         '@id': `${ctx.url}`,
       },
 
-      'publisher': {
+      publisher: {
         '@id': `${SITE_URL}/#organization`,
       },
 
-      'hasPart': {
+      hasPart: {
         '@type': 'Question',
-        'eduQuestionType': 'Multiple choice',
-        'learningResourceType': 'Practice Problem',
-        'encodingFormat': 'text/html',
+        eduQuestionType: 'Multiple choice',
+        learningResourceType: 'Practice Problem',
+        encodingFormat: 'text/html',
 
-        'image': typeof data.q_file === 'string' ? data.q_file : undefined,
-        'text': question,
-        'suggestedAnswer': answers,
+        image: typeof data.q_file === 'string' ? data.q_file : undefined,
+        text: question,
+        suggestedAnswer: answers,
         acceptedAnswer,
       },
     }
@@ -348,7 +369,7 @@ export function useSeoSchema() {
     }
 
     if (options.types.includes('breadcrumb')) {
-      schemas.push(createBreadcrumbSchema(options.breadcrumbs, options.url))
+      schemas.push(createBreadcrumbSchema(options.breadcrumbs))
     }
 
     if (options.types.includes('quiz')) {

--- a/app/composables/useSeoEngine.ts
+++ b/app/composables/useSeoEngine.ts
@@ -95,57 +95,57 @@ export function useSeoSchema() {
    * ---------------------------
    */
   const createArticleSchema = <TDto>(dto: TDto, ctx: SchemaContext<TDto>) => {
-  const url = new URL(ctx.url);
-  const parts = url.pathname.split("/").filter(Boolean);
-  const base = parts.slice(0, 2);
+    const url = new URL(ctx.url)
+    const parts = url.pathname.split('/').filter(Boolean)
+    const base = parts.slice(0, 2)
 
-  const articleBasePath = url.origin + "/" + base.join("/");    
-    
+    const articleBasePath = url.origin + '/' + base.join('/')
+
     const image
-    = (dto as Record<string, unknown>)?.thumb_pic
-      || (dto as Record<string, unknown>)?.lesson_pic
+      = (dto as Record<string, unknown>)?.thumb_pic
+        || (dto as Record<string, unknown>)?.lesson_pic
         || LOGO
 
     const up_date = (dto as Record<string, unknown>)?.up_date as
       | string
       | undefined
-    
-      const first_name = (dto as Record<string, unknown>)?.first_name as
-        | string
-      | undefined;
-    
-     const last_name = (dto as Record<string, unknown>)?.last_name as
-       | string
-      | undefined;
-    
-    const authorName = [first_name, last_name].filter(Boolean).join(" ");
+
+    const first_name = (dto as Record<string, unknown>)?.first_name as
+      | string
+      | undefined
+
+    const last_name = (dto as Record<string, unknown>)?.last_name as
+      | string
+      | undefined
+
+    const authorName = [first_name, last_name].filter(Boolean).join(' ')
 
     return {
-      "@type": "Article",
-      "@id": `${articleBasePath}#article`,
-      headline: ctx.title,
-      description: ctx.description,
-      image: [image],
+      '@type': 'Article',
+      '@id': `${articleBasePath}#article`,
+      'headline': ctx.title,
+      'description': ctx.description,
+      'image': [image],
 
-      mainEntityOfPage: {
-        "@type": "WebPage",
-        "@id": `${ctx.url}`,
+      'mainEntityOfPage': {
+        '@type': 'WebPage',
+        '@id': `${ctx.url}`,
       },
 
       ...(authorName && {
         author: {
-          "@type": "Person",
-          name: authorName,
+          '@type': 'Person',
+          'name': authorName,
         },
       }),
 
-      publisher: {
-        "@id": `${SITE_URL}/#organization`,
+      'publisher': {
+        '@id': `${SITE_URL}/#organization`,
       },
 
-      datePublished: (up_date && new Date(up_date).toISOString()) || undefined,
-      dateModified: (up_date && new Date(up_date).toISOString()) || undefined,
-    };
+      'datePublished': (up_date && new Date(up_date).toISOString()) || undefined,
+      'dateModified': (up_date && new Date(up_date).toISOString()) || undefined,
+    }
   }
 
   /**
@@ -170,30 +170,30 @@ export function useSeoSchema() {
       | undefined
 
     return {
-      "@type": "LearningResource",
-      "@id": `${ctx.url}#learning-resource`,
-      name: ctx.title,
-      url: ctx.url,
-      description: ctx.description,
+      '@type': 'LearningResource',
+      '@id': `${ctx.url}#learning-resource`,
+      'name': ctx.title,
+      'url': ctx.url,
+      'description': ctx.description,
 
-      body: ctx.body || undefined,
+      'body': ctx.body || undefined,
 
-      educationalUse: "Instruction",
-      learningResourceType: "Lesson",
-      educationalLevel: course && course !== "0" ? course : undefined,
-      teaches: headline,
-      datePublished: (up_date && new Date(up_date).toISOString()) || undefined,
-      inLanguage: ctx.lang || "en",
+      'educationalUse': 'Instruction',
+      'learningResourceType': 'Lesson',
+      'educationalLevel': course && course !== '0' ? course : undefined,
+      'teaches': headline,
+      'datePublished': (up_date && new Date(up_date).toISOString()) || undefined,
+      'inLanguage': ctx.lang || 'en',
 
-      mainEntityOfPage: {
-        "@type": "WebPage",
-        "@id": `${ctx.url}`,
+      'mainEntityOfPage': {
+        '@type': 'WebPage',
+        '@id': `${ctx.url}`,
       },
 
-      publisher: {
-        "@id": `${SITE_URL}/#organization`,
+      'publisher': {
+        '@id': `${SITE_URL}/#organization`,
       },
-    };
+    }
   }
 
   /**
@@ -226,7 +226,7 @@ export function useSeoSchema() {
       '@type': ['Article', 'LearningResource'],
       '@id': `${ctx.url}#learning-resource`,
 
-      articleBody: learning.body,
+      'articleBody': learning.body,
 
       ...learningProps,
     }
@@ -240,15 +240,15 @@ export function useSeoSchema() {
   const createBreadcrumbSchema = (
     items: BreadCrumb[] | undefined,
   ) => {
-    if (!items?.length) return null    
+    if (!items?.length) return null
 
     return {
       '@type': 'BreadcrumbList',
-      itemListElement: items.map((item, index) => ({
+      'itemListElement': items.map((item, index) => ({
         '@type': 'ListItem',
-        position: index + 1,
-        name: item.text,
-        item: `${SITE_URL}${item.href}`,
+        'position': index + 1,
+        'name': item.text,
+        'item': `${SITE_URL}${item.href}`,
       })),
     }
   }
@@ -270,8 +270,8 @@ export function useSeoSchema() {
       .filter((a): a is string => typeof a === 'string' && a.length > 0)
       .map((text, index) => ({
         '@type': 'Answer',
-        position: index + 1,
-        encodingFormat: 'text/html',
+        'position': index + 1,
+        'encodingFormat': 'text/html',
         text,
       }))
 
@@ -281,27 +281,27 @@ export function useSeoSchema() {
     return {
       '@type': 'Quiz',
       '@id': `${ctx.url}#quiz`,
-      inLanguage: ctx.lang || 'en',
-      learningResourceType: 'Assessment',
+      'inLanguage': ctx.lang || 'en',
+      'learningResourceType': 'Assessment',
 
-      mainEntityOfPage: {
+      'mainEntityOfPage': {
         '@type': 'WebPage',
         '@id': `${ctx.url}`,
       },
 
-      publisher: {
+      'publisher': {
         '@id': `${SITE_URL}/#organization`,
       },
 
-      hasPart: {
+      'hasPart': {
         '@type': 'Question',
-        eduQuestionType: 'Multiple choice',
-        learningResourceType: 'Practice Problem',
-        encodingFormat: 'text/html',
+        'eduQuestionType': 'Multiple choice',
+        'learningResourceType': 'Practice Problem',
+        'encodingFormat': 'text/html',
 
-        image: typeof data.q_file === 'string' ? data.q_file : undefined,
-        text: question,
-        suggestedAnswer: answers,
+        'image': typeof data.q_file === 'string' ? data.q_file : undefined,
+        'text': question,
+        'suggestedAnswer': answers,
         acceptedAnswer,
       },
     }

--- a/app/pages/paper/[id]/[[slug]].vue
+++ b/app/pages/paper/[id]/[[slug]].vue
@@ -122,12 +122,11 @@ interface BreadCrumb {
   disabled: boolean
   href: string
 }
-interface SchemaNode {
-  [key: string]: string | object
-}
 
 const route = useRoute()
 const router = useRouter()
+
+const { buildSchema } = useSeoSchema()
 
 const requestURL = ref(useRequestURL().host)
 const pageDescribe = ref('')
@@ -178,86 +177,39 @@ const { data: contentData } = await useAsyncData(
   },
 )
 
-const organizationSchema = {
-  '@type': 'Organization',
-  '@id': 'https://gamatrain.com/#organization',
-  'name': 'GamaTrain',
-  'url': 'https://gamatrain.com',
-  'logo': {
-    '@type': 'ImageObject',
-    'url': 'https://gamatrain.com/android-chrome-512x512-light.png',
-  },
-}
-const breadcrumbSchema = computed(() => {
-  if (!breads.value.length) return null
-
-  return {
-    '@type': 'BreadcrumbList',
-    'itemListElement': breads.value.map((item, index) => ({
-      '@type': 'ListItem',
-      'position': index + 1,
-      'name': item.text,
-      'item': `https://${requestURL.value}${item.href}`,
-    })),
-  }
-})
-
-const articleSchema = computed(() => {
+const schema = computed(() => {
   if (!contentData.value) return null
 
-  const image
-    = contentData.value.thumb_pic
-      || contentData.value.lesson_pic
-      || 'https://gamatrain.com/android-chrome-512x512-light.png'
+  const dto = contentData.value
 
-  return {
-    '@type': 'Article',
-    '@id': `https://${requestURL.value}/paper/${contentData.value.id}#article`,
-    'headline': pageTitle.value,
-    'description': pageDescribe.value,
-    'image': [image],
-    'mainEntityOfPage': {
-      '@type': 'WebPage',
-      '@id': `https://${requestURL.value}/paper/${contentData.value.id}/${contentData.value.title_url}`,
-    },
-    'author': {
-      '@type': 'Person',
-      'name': `${contentData.value.first_name} ${contentData.value.last_name}`,
-    },
-    'publisher': {
-      '@type': 'Organization',
-      '@id': 'https://gamatrain.com/#organization',
-    },
-    'dateModified': new Date(contentData.value.up_date).toISOString(),
-    'datePublished': new Date(contentData.value.up_date).toISOString(),
-  }
-})
+  const url = `https://${requestURL.value}/paper/${dto.id}/${dto.title_url}`
 
-const fullSchema = computed(() => {
-  if (!articleSchema.value) return null
+  const title = pageTitle.value
+  const description = pageDescribe.value
 
-  const graph: SchemaNode[] = [
-    organizationSchema,
-    articleSchema.value,
-  ]
-
-  if (breadcrumbSchema.value) {
-    graph.push(breadcrumbSchema.value)
-  }
-
-  return {
-    '@context': 'https://schema.org',
-    '@graph': graph,
-  }
+  return buildSchema({
+    dto,
+    url,
+    title,
+    description,
+    breadcrumbs: breads.value,
+    types: ['article', 'breadcrumb'],
+  })
 })
 
 const setMetaData = () => {
   if (!contentData.value) return
 
-  const { section_title, base_title, title, is_paper } = contentData.value
+  const dto: PastPaperDTO = contentData.value
+  const { section_title, base_title, title, is_paper } = dto
 
-  // Build common title parts
-  const titleParts = [section_title, base_title, title].filter(Boolean)
+  // Build title parts safely from DTO
+  const titleParts = [
+    section_title,
+    base_title,
+    title,
+  ].filter(Boolean)
+
   const baseTitle = titleParts.join(' ')
 
   if (is_paper) {
@@ -269,8 +221,8 @@ const setMetaData = () => {
     pageDescribe.value = `Free download of ${title} – ${base_title}, ${section_title} curriculum. Ideal for quick revision, practice, and exam prep.`
   }
 
-  const ogImage = contentData.value?.thumb_pic
-    ? contentData.value?.thumb_pic
+  const ogImage = dto.thumb_pic
+    ? dto.thumb_pic
     : null
 
   useHead({
@@ -317,18 +269,19 @@ const setMetaData = () => {
         content: ogImage,
       },
     ],
-    script: [
+    script: schema.value
+      ? [
       {
         key: 'json-ld-schema',
         type: 'application/ld+json',
-        innerHTML: JSON.stringify(fullSchema.value),
+        innerHTML: JSON.stringify(schema.value),
       },
-    ],
+    ]:[],
     link: [
       {
         rel: 'canonical',
-        href: contentData.value
-          ? `https://${requestURL.value}/paper/${contentData.value.id}/${contentData.value.title_url}`
+        href: dto
+          ? `https://${requestURL.value}/paper/${dto.id}/${dto.title_url}`
           : `https://${requestURL.value}/paper/${route.params.id}`,
       },
     ],

--- a/app/pages/paper/[id]/[[slug]].vue
+++ b/app/pages/paper/[id]/[[slug]].vue
@@ -33,6 +33,7 @@
           :id="contentData.id"
           :thumb-pic="contentData.thumb_pic"
           :title="contentData.title"
+          :alt="pageTitle"
           :views="contentData.views"
           :score="contentData.ref_score"
           @share="openShare = true"

--- a/app/pages/paper/[id]/[[slug]].vue
+++ b/app/pages/paper/[id]/[[slug]].vue
@@ -271,12 +271,13 @@ const setMetaData = () => {
     ],
     script: schema.value
       ? [
-      {
-        key: 'json-ld-schema',
-        type: 'application/ld+json',
-        innerHTML: JSON.stringify(schema.value),
-      },
-    ]:[],
+          {
+            key: 'json-ld-schema',
+            type: 'application/ld+json',
+            innerHTML: JSON.stringify(schema.value),
+          },
+        ]
+      : [],
     link: [
       {
         rel: 'canonical',

--- a/app/types/pastpaper/index.ts
+++ b/app/types/pastpaper/index.ts
@@ -15,33 +15,34 @@ export interface FilesDTO {
 }
 
 export interface PastPaperDTO {
-  id: string
-  title: string
-  title_url: string
-  thumb_pic: string
-  lesson_pic: string | null
-  description: string
-  views: number
-  ref_score: number
-  edu_year: string
-  section: string
-  base: string
-  lesson: string
+  id: string;
+  title: string;
+  title_url: string;
+  thumb_pic: string;
+  lesson_pic: string | null;
+  description: string;
+  views: number;
+  ref_score: number;
+  edu_year: string;
+  section: string;
+  base: string;
+  lesson: string;
   exams: {
-    id: string
-    status: string
-  }[]
-  files: FilesDTO
-  lesson_title: string
-  base_title: string
-  section_title: string
-  is_paper: boolean
-  avatar: string
-  first_name: string
-  last_name: string
-  test_type_title?: string
-  up_date: string
-  edu_month_title: string
+    id: string;
+    status: string;
+  }[];
+  files: FilesDTO;
+  lesson_title: string;
+  base_title: string;
+  section_title: string;
+  is_paper: boolean;
+  avatar: string;
+  first_name: string;
+  last_name: string;
+  test_type: string;
+  test_type_title?: string;
+  up_date: string;
+  edu_month_title: string;
 }
 
 export interface ContentItemDTO {

--- a/app/types/pastpaper/index.ts
+++ b/app/types/pastpaper/index.ts
@@ -15,34 +15,34 @@ export interface FilesDTO {
 }
 
 export interface PastPaperDTO {
-  id: string;
-  title: string;
-  title_url: string;
-  thumb_pic: string;
-  lesson_pic: string | null;
-  description: string;
-  views: number;
-  ref_score: number;
-  edu_year: string;
-  section: string;
-  base: string;
-  lesson: string;
+  id: string
+  title: string
+  title_url: string
+  thumb_pic: string
+  lesson_pic: string | null
+  description: string
+  views: number
+  ref_score: number
+  edu_year: string
+  section: string
+  base: string
+  lesson: string
   exams: {
-    id: string;
-    status: string;
-  }[];
-  files: FilesDTO;
-  lesson_title: string;
-  base_title: string;
-  section_title: string;
-  is_paper: boolean;
-  avatar: string;
-  first_name: string;
-  last_name: string;
-  test_type: string;
-  test_type_title?: string;
-  up_date: string;
-  edu_month_title: string;
+    id: string
+    status: string
+  }[]
+  files: FilesDTO
+  lesson_title: string
+  base_title: string
+  section_title: string
+  is_paper: boolean
+  avatar: string
+  first_name: string
+  last_name: string
+  test_type: string
+  test_type_title?: string
+  up_date: string
+  edu_month_title: string
 }
 
 export interface ContentItemDTO {


### PR DESCRIPTION
## Description

This PR improves the past paper page implementation by switching SEO schema generation from a static approach to a dynamic one using the `useSeoEngine` composable. It also enhances accessibility and SEO by updating image alt text and resolves a TypeScript type issue by adding a missing DTO field type.

Fixes #1004 

## Type of Change

- [x] Bug fix

## Checklist

- Replaced static image alt text with auto-generated page title to improve SEO and accessibility
- Refactored past paper page schema generation replacing static schema with dynamic generation using **useSeoEngine**
- Added missing `test_type` field to `PastPaperDTO` to resolve TypeScript type errors
