### PR TITLE
fix(tutorial-title): remove unwanted prefix for toturial pages title

### DIFF
--- a/app/pages/tutorial/[id]/[[slug]].vue
+++ b/app/pages/tutorial/[id]/[[slug]].vue
@@ -365,14 +365,17 @@ const setMetaData = () => {
 
   const dto: TutorialDTO = contentData.value
 
-  // Build title parts safely from DTO
-  const titleParts = [
-    dto.section_title,
-    dto.base_title,
-    dto.title,
-  ].filter(Boolean)
+  const isGamaBoard = dto.section === '7131'
 
-  const baseTitle = titleParts.join(' ')
+  const baseTitle = (
+    isGamaBoard
+      // GAMA: use only the title
+      ? [dto.title]
+      // Other boards: include section, base title, and title
+      : [dto.section_title, dto.base_title, dto.title]
+  )
+    .filter(Boolean)
+    .join(' ')
 
   pageTitle.value = baseTitle
 


### PR DESCRIPTION
## Description

This PR removes the automatically generated board prefix from tutorial titles for **GAMA board** tutorials only.

Fixes #1005 

## Type of Change

- [x] Bug fix

## Checklist

- Removed automatic GAMA board title prefix generation.
- Applied the change only to tutorials belonging to the GAMA board (_section = 7131_).
- Preserved existing title generation behavior for all other boards.
- Ensured only the intended tutorial title is displayed.
