### PR TITLE
feat(tutorial-tree): make tutorial detail side navigation sticky

### DIFF
--- a/app/pages/tutorial/[id]/[[slug]].vue
+++ b/app/pages/tutorial/[id]/[[slug]].vue
@@ -9,10 +9,12 @@
         md="3"
         class="pa-0"
       >
-        <tutorial-lesson-tree
-          v-model:show-drawer="showLessonTree"
-          :units="lessonTree?.list ?? []"
-        />
+        <div class="tree-container">
+          <tutorial-lesson-tree
+            v-model:show-drawer="showLessonTree"
+            :units="lessonTree?.list ?? []"
+          />
+        </div>
       </v-col>
       <v-col
         cols="12"
@@ -474,6 +476,14 @@ if (contentData.value) {
   right: 12px;
   bottom : 70px;
   z-index : 3
+}
+
+@media (min-width: 960px) {
+  .tree-container {
+    position: sticky;
+    top: 70px;
+    height: 100vh;
+  }
 }
 
 .book-content {


### PR DESCRIPTION
## Description

Improves the desktop UX of the tutorial detail side navigation and ensuring the lesson tree remains visible while scrolling content.

Fixes #1015 

## Type of Change

- [x] New feature

## Checklist

- Sidebar stays sticky on desktop viewports
- Tree list scrolls independently
- Full height layout preserved
- No layout shift in Vuetify drawer
- Works correctly in all browsers
- Mobile layout unchanged
