### PR TITLE
feat(admin): Link DownloadPastPaper transactions to paper details

### DIFF
--- a/app/pages/admin/transactions/index.vue
+++ b/app/pages/admin/transactions/index.vue
@@ -141,7 +141,14 @@
           <div
             class="text-grey600 text-h5 d-flex justify-start align-center font-weight-bold"
           >
-            {{ item.description }}
+           <NuxtLink v-if="item.transactionType === 'DownloadPastPaper'" :to="`/paper/${item.identifierId}`"
+              target="_blank" rel="noopener noreferrer">
+              {{ item.description }} ({{ item.identifierId }})
+            </NuxtLink>
+
+            <span v-else>
+              {{ item.description }}
+            </span>
           </div>
         </template>
       </v-data-table>

--- a/app/pages/admin/transactions/index.vue
+++ b/app/pages/admin/transactions/index.vue
@@ -142,7 +142,7 @@
             class="text-grey600 text-h5 d-flex justify-start align-center font-weight-bold"
           >
            <NuxtLink v-if="item.transactionType === 'DownloadPastPaper'" :to="`/paper/${item.identifierId}`"
-              target="_blank" rel="noopener noreferrer">
+              target="_blank" rel="noopener noreferrer" class="text-decoration-none">
               {{ item.description }} ({{ item.identifierId }})
             </NuxtLink>
 
@@ -337,6 +337,9 @@ const refreshData = async () => {
 }
 .select-size-div {
   top: 18px;
+}
+.text-decoration-none:hover {
+  text-decoration: underline !important;
 }
 
 :deep(.custom-pagination li button:hover) {

--- a/app/types/transaction/index.ts
+++ b/app/types/transaction/index.ts
@@ -6,6 +6,8 @@ export interface AdminTransactionDTO {
   creationDate: string
   currentBalance: number
   isDebit: boolean
+  transactionType: string
+  identifierId: number
 }
 export interface TransactionStatisticDTO {
   name: string


### PR DESCRIPTION
## Description

Adds links for DownloadPastPaper transactions so users can open the related past paper details page in a new browser tab. Other transaction types continue to be displayed as plain text.

Fixes #1029 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Changes:

* Render `DownloadPastPaper` transaction descriptions as clickable `NuxtLink` components.
* Include the paper identifier (`identifierId`) in the link text.
* Navigate to the corresponding paper details page using `/paper/{identifierId}`.
* Open paper links in a new browser tab using `target="_blank"` with `rel="noopener noreferrer"` for security.
* Preserve the existing rendering behavior for all other transaction types.


## Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings/errors  
- [ ] I have added tests that prove my fix is effective or that my feature works