### PR TITLE
fix(test): restore Question: title in TestDetails

### DIFF
--- a/app/components/common/header.vue
+++ b/app/components/common/header.vue
@@ -134,7 +134,7 @@
     <lazy-common-modal-base
       v-model:show-dialog="isAddOptionOpen"
       title="What would you like to create?"
-      subtitle="hoose a type. We will prepare the right form for you."
+      subtitle="Choose a type. We will prepare the right form for you."
     >
       <menu-add-option-bottom-menu
         @close="isAddOptionOpen = false"

--- a/app/components/menu/BottomNavMenu.vue
+++ b/app/components/menu/BottomNavMenu.vue
@@ -110,7 +110,7 @@
   <lazy-common-modal-base
     v-model:show-dialog="isAddOptionOpen"
     title="What would you like to create?"
-    subtitle="hoose a type. We will prepare the right form for you."
+    subtitle="Choose a type. We will prepare the right form for you."
   >
     <menu-add-option-bottom-menu
       @close="isAddOptionOpen = false"

--- a/app/components/test/TestDetails.vue
+++ b/app/components/test/TestDetails.vue
@@ -22,6 +22,12 @@
     </div>
     <div class="w-100 d-flex align-center mt-4">
       <div
+        v-if="showTitle"
+        class="text-h4 font-weight-bold text-grey600"
+      >
+        Question:
+      </div>
+      <div
         v-if="contentData.answer_full.length > 0"
         class="w-100 d-flex align-center justify-end"
       >


### PR DESCRIPTION
## Summary
- PR #1049 refactored `TestDetails.vue` (chips + typography) and, as a side effect, deleted the `v-if="showTitle"` "Question:" heading block while leaving the `showTitle` prop declared and still passed as `true` from `app/pages/test/[id].vue`.
- Result: the "Question:" heading silently disappeared from the main `/test/[id]` page after #1049 merged.
- This PR restores the heading block exactly as it was, gated on the existing `showTitle` prop.

## Test plan
- [ ] Visit `/test/:id` and confirm the "Question:" heading renders above the question content again.
- [ ] Confirm pages that don't pass `show-title` (exam, exam-papers, test-maker, albums, BoxRandomQuestion) are unaffected.