### PR TITLE
fix(auth): improve sign-in flow and responsive UI

### DIFF
--- a/app/components/common/googleLoginButton.vue
+++ b/app/components/common/googleLoginButton.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="w-100 d-flex align-center justify-center">
+  <div class="google-login-container w-100 d-flex align-center justify-center">
     <div
       v-show="googleLoginLoading || loadingLoginByGoogle"
-      class="login-google py-2 px-3"
+      class="login-google px-3"
     >
       <v-progress-circular
         color="primary"
@@ -17,6 +17,7 @@
     <div
       v-show="!googleLoginLoading && !loadingLoginByGoogle"
       ref="googleLoginBtn"
+      class="google-login-button w-100"
     />
   </div>
 </template>
@@ -70,7 +71,17 @@ onMounted(() => {
 
 <style scoped>
 .login-google{
+  width: 100%;
+  min-height: 44px;
   border : 1px solid rgb(var(--v-theme-grey200));
-  border-radius: 4px;
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.google-login-container,
+.google-login-button {
+  min-height: 44px;
 }
 </style>

--- a/app/components/common/modal/auth/index.vue
+++ b/app/components/common/modal/auth/index.vue
@@ -2,11 +2,12 @@
   <div v-if="dialogModel">
     <lazy-common-modal-base
       v-model:show-dialog="showLoginModal"
-      title="Login"
+      title="Sign in"
     >
       <common-modal-auth-login
         @login-successfull="handleLoginSuccessfull"
         @open-register="openRegisterModal"
+        @open-register-otp="openOTPModalForRegister"
         @open-forget-password="openForgetPasswordModal"
         @open-otp-code="openOTPModalForLogin"
         @close="closeAuthFlow"

--- a/app/components/common/modal/auth/login.vue
+++ b/app/components/common/modal/auth/login.vue
@@ -2,10 +2,12 @@
   <div
     class="w-100 d-flex flex-wrap flex-column bg-white pa-2"
   >
-    <common-google-login-button @login-successfull="emit('loginSuccessfull')" />
-
-    <v-form v-model="isFormValid">
-      <div class="w-100 d-flex flex-column align-start justify-start ga-1 mt-4">
+    <v-form
+      v-model="isFormValid"
+      class="w-100"
+      @submit.prevent="loginUser"
+    >
+      <div class="w-100 d-flex flex-column align-start justify-start ga-1 mt-2 mb-4">
         <div class="text-h6 text-grey700 font-weight-bold ml-2">
           Email
         </div>
@@ -14,8 +16,10 @@
           rounded="lg"
           height="48"
           placeholder="Email"
+          type="email"
           variant="outlined"
-          autocomplete="off"
+          autocomplete="email"
+          hide-details="auto"
           persistent-clear
           base-color="grey200"
           color="primary"
@@ -36,7 +40,8 @@
           height="48"
           placeholder="Password"
           variant="outlined"
-          autocomplete="off"
+          autocomplete="current-password"
+          hide-details="auto"
           persistent-clear
           base-color="grey200"
           color="primary"
@@ -51,64 +56,57 @@
           @click:append-inner="showCurrentPassword = !showCurrentPassword"
         />
       </div>
-    </v-form>
 
-    <span
-      class="w-100 font-weight-medium text-h5 text-grey700 mt-4 text-start cursor-pointer"
-      @click="emit('openForgetPassword')"
-    >Forget password?</span>
+      <div class="w-100 d-flex justify-end mt-1">
+        <v-btn
+          type="button"
+          variant="text"
+          color="primary"
+          density="compact"
+          class="px-0 text-h6 font-weight-bold"
+          @click="emit('openForgetPassword')"
+        >
+          Forgot password?
+        </v-btn>
+      </div>
 
-    <v-divider
-      :thickness="2"
-      class="border-opacity-100 mt-8"
-      color="grey200"
-    />
-    <span
-      class="w-100 font-weight-medium text-h5 text-grey700 mt-4 text-center cursor-pointer"
-      @click="emit('openRegister')"
-    >Not registered? <span class="text-primary font-weight-bold">Register now
-    </span>
-    </span>
-    <v-divider
-      :thickness="2"
-      class="border-opacity-100 mt-4"
-      color="grey200"
-    />
-
-    <div class="w-100 d-flex justify-center align-center ga-2 mt-4">
       <v-btn
-        color="grey200"
-        variant="outlined"
-        rounded="pill"
-        height="38"
-        width="120"
-        class="text-h5 font-weight-medium"
-        flat
-        @click="emit('close')"
-      >
-        <span class="text-grey800">
-          Cancel
-        </span>
-      </v-btn>
-      <v-btn
+        type="submit"
+        block
         color="primary"
         rounded="pill"
-        height="38"
-        width="180"
-        class="text-h5 text-grey800 font-weight-medium"
+        height="44"
+        class="mt-2 text-h5 text-grey800 font-weight-bold"
         flat
         :disabled="!isFormValid"
         :loading="loadingLogin"
-        @click="loginUser"
       >
-        Login
+        Sign in
       </v-btn>
+    </v-form>
+
+    <div class="w-100 d-flex align-center ga-3 my-4">
+      <v-divider color="grey200" />
+      <span class="text-h6 text-grey500">or</span>
+      <v-divider color="grey200" />
     </div>
+
+    <common-google-login-button @login-successfull="emit('loginSuccessfull')" />
+
+    <v-btn
+      variant="text"
+      color="grey700"
+      class="mt-3 text-h6 font-weight-medium text-none"
+      @click="emit('openRegister')"
+    >
+      New to GamaTrain?
+      <span class="ml-1 text-primary font-weight-bold">Create account</span>
+    </v-btn>
   </div>
 </template>
 
 <script setup lang="ts">
-const emit = defineEmits(['loginSuccessfull', 'openRegister', 'openForgetPassword', 'openOtpCode', 'close'])
+const emit = defineEmits(['loginSuccessfull', 'openRegister', 'openRegisterOtp', 'openForgetPassword', 'openOtpCode', 'close'])
 
 const { $toast } = useNuxtApp()
 const { email, required } = useValidationRules()
@@ -132,7 +130,8 @@ const loginUser = async () => {
       emit('openOtpCode', emailUser.value, password.value)
     }
     else if (response.data.type == 'register') {
-      emit('openRegister')
+      $toast.success('Verification code sent.')
+      emit('openRegisterOtp', emailUser.value)
     }
     else if (response.data.token) {
       setUserToken(response.data.token)

--- a/app/components/common/modal/auth/otp.vue
+++ b/app/components/common/modal/auth/otp.vue
@@ -2,12 +2,8 @@
   <div
     class="w-100 d-flex flex-wrap flex-column bg-white pa-2"
   >
-    <common-google-login-button
-      @login-successfull="emit('loginSuccessfull')"
-    />
-
     <span
-      class="w-100 font-weight-medium text-h5 text-grey700 mt-6 text-start"
+      class="w-100 font-weight-medium text-h5 text-grey700 mt-4 text-start"
     >Please enter the code received on your email address:</span>
 
     <v-otp-input

--- a/app/components/common/modal/base.vue
+++ b/app/components/common/modal/base.vue
@@ -11,7 +11,7 @@
     >
       <div class="w-100 d-flex align-center justify-space-between">
         <div class="d-flex flex-column align-start justify-start ga-1">
-          <span class="text-h5 text-sm-h3 font-weight-bold text-grey700">{{ title }}</span>
+          <span class="modal-title text-h5 text-sm-h3 font-weight-bold text-grey700">{{ title }}</span>
           <span
             v-if="subtitle"
             class="text-subtitle-1 text-sm-h6 font-weight-medium text-grey400"
@@ -77,6 +77,10 @@ const clickOnModal = (event: MouseEvent) => {
 <style>
 .mobile-style{
   max-height: 90%;
+}
+.modal-title {
+  line-height: 1.3 !important;
+  padding-bottom: 2px;
 }
 .ck ol, .ck ul{
   padding-left : 24px !important;

--- a/app/composables/useGoogleLogin.ts
+++ b/app/composables/useGoogleLogin.ts
@@ -3,6 +3,18 @@ import type { GoogleLoginTokenDTO } from '@/types'
 export const useGoogleLogin = () => {
   const loading = ref(true)
   const error = ref<Error | null>(null)
+  let resizeObserver: ResizeObserver | null = null
+  let resizeFrame: number | null = null
+
+  const stopResponsiveRendering = () => {
+    resizeObserver?.disconnect()
+    resizeObserver = null
+
+    if (resizeFrame !== null) {
+      cancelAnimationFrame(resizeFrame)
+      resizeFrame = null
+    }
+  }
 
   const loadScript = () => {
     return new Promise<boolean>((resolve, reject) => {
@@ -57,12 +69,47 @@ export const useGoogleLogin = () => {
         auto_select: true,
       })
 
-      window.google.accounts.id.renderButton(buttonEl, {
-        text: 'signin_with',
-        size: 'large',
-        width: 252,
-        theme: 'outline',
-      })
+      let renderedWidth = 0
+      const renderButton = () => {
+        const availableWidth
+          = buttonEl.parentElement?.clientWidth || buttonEl.clientWidth
+
+        if (!availableWidth) {
+          return
+        }
+
+        const nextWidth = Math.min(Math.floor(availableWidth), 400)
+        if (nextWidth === renderedWidth) {
+          return
+        }
+
+        renderedWidth = nextWidth
+        buttonEl.replaceChildren()
+        window.google.accounts.id.renderButton(buttonEl, {
+          text: 'signin_with',
+          size: 'large',
+          shape: 'pill',
+          width: nextWidth,
+          theme: 'outline',
+        })
+      }
+
+      renderButton()
+
+      if (buttonEl.parentElement && 'ResizeObserver' in window) {
+        stopResponsiveRendering()
+        resizeObserver = new ResizeObserver(() => {
+          if (resizeFrame !== null) {
+            cancelAnimationFrame(resizeFrame)
+          }
+
+          resizeFrame = requestAnimationFrame(() => {
+            resizeFrame = null
+            renderButton()
+          })
+        })
+        resizeObserver.observe(buttonEl.parentElement)
+      }
     }
     catch (e) {
       error.value = e as Error
@@ -72,6 +119,8 @@ export const useGoogleLogin = () => {
       loading.value = false
     }
   }
+
+  onScopeDispose(stopResponsiveRendering)
 
   return {
     loading,


### PR DESCRIPTION
## Summary
- compact and clarify the sign-in form layout
- route unregistered login responses directly into registration OTP verification
- make the Google sign-in button pill-shaped and responsive, including viewport resizing
- remove Google sign-in from the OTP screen
- align sign-in terminology and prevent auth dialog title glyph clipping

## Validation
- npm run lint:check
- git diff --check
- responsive browser checks at 320px
- sandbox legacy-auth API behavior verified

## Notes
- Production client and server compilation completed successfully during validation; the final Nitro packaging run was stopped at user request.