### PR TITLE
fix(paper-detail): fix HTML entity rendering in Paper Detail descriptions

### DIFF
--- a/app/components/common/detail/ContentDetailsSection.vue
+++ b/app/components/common/detail/ContentDetailsSection.vue
@@ -26,8 +26,8 @@
     <div
       v-if="!seeCompleteDescription"
       class="blur-div position-absolute h-100 w-100 left-0 bottom-0"
+      v-html="contentData?.description"
     />
-    {{ contentData?.description }}
   </div>
   <span
     class="w-100 cursor-pointer text-h5 d-flex align-center color-link ga-1 mt-1"


### PR DESCRIPTION
## Description

Fixed HTML entity rendering in paper detail descriptions by switching to HTML rendering, ensuring entities like `&amp;` display correctly without modifying the original content.

Fixes #1059 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Changes

- Updated paper detail description rendering to use HTML rendering instead of plain text interpolation.
- Fixed HTML entities such as &amp; being displayed incorrectly as raw text (&amp;).
- Ensured the change only affects the rendered description output and does not modify the original content data.

## Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings/errors  
- [ ] I have added tests that prove my fix is effective or that my feature works
