### PR TITLE
fix(build): support Rolldown manual chunks

### DIFF
--- a/app/pages/leader-board.vue
+++ b/app/pages/leader-board.vue
@@ -477,7 +477,7 @@ if (initialData.value && initialData.value.succeeded) {
   position: relative;
 
   #main-title-holder {
-    background-image: url("public/images/leaderBoard-Rectangle.png");
+    background-image: url("/images/leaderBoard-Rectangle.png");
     background-position: center;
     position: absolute;
     margin: auto;
@@ -503,7 +503,7 @@ if (initialData.value && initialData.value.succeeded) {
 }
 
 #submain-title-holder {
-  background-image: url("public/images/leaderBoard-reverseRectangle.png");
+  background-image: url("/images/leaderBoard-reverseRectangle.png");
   background-position: center;
   position: absolute;
   margin: auto;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -262,11 +262,17 @@ export default defineNuxtConfig({
       chunkSizeWarningLimit: 1000,
       rollupOptions: {
         output: {
-          manualChunks: {
-            vendor: ['vue', 'vue-router'],
-            vuetify: ['vuetify'],
-            charts: ['vue-chartjs', 'chart.js'],
-            ckeditor: ['@ckeditor/ckeditor5-vue'],
+          manualChunks(id) {
+            const normalizedId = id.replaceAll('\\', '/')
+
+            if (/\/node_modules\/(?:vue|vue-router|@vue)\//.test(normalizedId))
+              return 'vendor'
+            if (normalizedId.includes('/node_modules/vuetify/'))
+              return 'vuetify'
+            if (/\/node_modules\/(?:vue-chartjs|chart\.js)\//.test(normalizedId))
+              return 'charts'
+            if (normalizedId.includes('/node_modules/@ckeditor/ckeditor5-vue/'))
+              return 'ckeditor'
           },
         },
       },


### PR DESCRIPTION
## Summary
- replace object-form manualChunks with a function-based module classifier compatible with Vite/Rolldown
- preserve the existing vendor, Vuetify, charts, and CKEditor chunk groups
- correct leaderboard public image URLs so Vite does not attempt to resolve them at build time

## Cause
The repository has no package lock, so clean Vercel deployments can resolve newer build-tool behavior. The Rolldown path expects manualChunks to be a function and rejects the existing Rollup object form.

## Verification
- npm run build
- production build completed successfully
- manualChunks validation and TypeError are gone
- leaderboard image resolution warnings are gone

## Existing warnings
The build still reports unrelated stale browser-data, pdf.js eval, and large-chunk warnings.