### PR TITLE
fix(paper-detail): fix see more/less description bug

### DIFF
--- a/app/components/common/detail/ContentDetailsSection.vue
+++ b/app/components/common/detail/ContentDetailsSection.vue
@@ -24,9 +24,12 @@
     }`"
   >
     <div
-      v-if="!seeCompleteDescription"
-      class="blur-div position-absolute h-100 w-100 left-0 bottom-0"
       v-html="contentData?.description"
+    />
+
+    <div
+      v-if="!seeCompleteDescription"
+      class="blur-div position-absolute left-0 bottom-0 w-100"
     />
   </div>
   <span
@@ -140,6 +143,7 @@ const seeCompleteDescription = ref(false)
   overflow: hidden;
 }
 .blur-div {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #ffffff 80%);
+  height: 40px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%,#ffffff 80%);
 }
 </style>


### PR DESCRIPTION
## Description

Fix paper description disappearing after clicking **See More**.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Changes
- Fixed paper description disappearing when toggling See More
- Updated description rendering to keep content mounted while applying blur overlay