### PR TITLE
fix(paper-detail): make description toggle responsive

### DIFF
--- a/app/components/common/detail/ContentDetailsSection.vue
+++ b/app/components/common/detail/ContentDetailsSection.vue
@@ -24,9 +24,12 @@
     }`"
   >
     <div
-      v-if="!seeCompleteDescription"
-      class="blur-div position-absolute h-100 w-100 left-0 bottom-0"
       v-html="contentData?.description"
+    />
+
+    <div
+      v-if="!seeCompleteDescription"
+      class="blur-div position-absolute left-0 bottom-0 w-100"
     />
   </div>
   <span
@@ -140,6 +143,7 @@ const seeCompleteDescription = ref(false)
   overflow: hidden;
 }
 .blur-div {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #ffffff 80%);
+  height: 40px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%,#ffffff 80%);
 }
 </style>

--- a/app/components/common/detail/ContentDetailsSection.vue
+++ b/app/components/common/detail/ContentDetailsSection.vue
@@ -24,21 +24,27 @@
     }`"
   >
     <div
+      ref="descriptionContent"
       v-html="contentData?.description"
     />
 
     <div
-      v-if="!seeCompleteDescription"
+      v-if="hasOverflow && !seeCompleteDescription"
       class="blur-div position-absolute left-0 bottom-0 w-100"
     />
   </div>
-  <span
-    class="w-100 cursor-pointer text-h5 d-flex align-center color-link ga-1 mt-1"
+  <button
+    v-if="hasOverflow"
+    type="button"
+    class="w-100 pa-0 bg-transparent border-0 text-left cursor-pointer text-h5 d-flex align-center color-link ga-1 mt-1"
+    :aria-expanded="seeCompleteDescription"
     @click="seeCompleteDescription = !seeCompleteDescription"
   >
     {{ seeCompleteDescription ? `See Less` : `See More` }}
-    <v-icon color="#1a73e8">md:chevron_forward</v-icon>
-  </span>
+    <v-icon color="#1a73e8">
+      {{ seeCompleteDescription ? 'md:keyboard_arrow_up' : 'md:keyboard_arrow_down' }}
+    </v-icon>
+  </button>
 
   <div class="w-100 d-flex align-center justify-space-between mt-8">
     <span class="text-h5 d-flex align-center primary-gray-600 ga-1">
@@ -119,7 +125,7 @@ interface IContentDetailsSection {
   edu_year: string
 }
 
-defineProps<{
+const props = defineProps<{
   contentData: IContentDetailsSection
 }>()
 
@@ -127,6 +133,37 @@ const { $dayjs } = useNuxtApp()
 const { mdAndDown } = useDisplay()
 
 const seeCompleteDescription = ref(false)
+const descriptionContent = ref<HTMLElement | null>(null)
+const hasOverflow = ref(false)
+const collapsedDescriptionHeight = 70
+let descriptionResizeObserver: ResizeObserver | null = null
+
+function updateDescriptionOverflow() {
+  hasOverflow.value = (descriptionContent.value?.scrollHeight ?? 0) > collapsedDescriptionHeight
+}
+
+onMounted(async () => {
+  await nextTick()
+  updateDescriptionOverflow()
+
+  if (descriptionContent.value && typeof ResizeObserver !== 'undefined') {
+    descriptionResizeObserver = new ResizeObserver(updateDescriptionOverflow)
+    descriptionResizeObserver.observe(descriptionContent.value)
+  }
+})
+
+watch(
+  () => props.contentData?.description,
+  async () => {
+    seeCompleteDescription.value = false
+    await nextTick()
+    updateDescriptionOverflow()
+  },
+)
+
+onBeforeUnmount(() => {
+  descriptionResizeObserver?.disconnect()
+})
 </script>
 
 <style scoped>
@@ -139,11 +176,12 @@ const seeCompleteDescription = ref(false)
   overflow: unset;
 }
 .close-description {
-  height: 70px;
+  max-height: 70px;
   overflow: hidden;
 }
 .blur-div {
   height: 40px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%,#ffffff 80%);
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #ffffff 80%);
 }
 </style>


### PR DESCRIPTION
## Summary

- preserve the paper description when toggling See More/See Less
- show the toggle only when the rendered description exceeds the collapsed height
- recalculate overflow when responsive wrapping changes the content height
- remove the fixed-height gap for short descriptions
- use an accessible button and Vuetify utility classes

This builds on and supersedes #1065.

## Testing

- `npx eslint app/components/common/detail/ContentDetailsSection.vue`
- `git diff --check upstream/upgrade-v4...HEAD`

Full build was not run.