### PR TITLE
fix(test-detail): refine responsive answer option layout

### DIFF
--- a/app/components/common/detail/BoxRandomQuestion.vue
+++ b/app/components/common/detail/BoxRandomQuestion.vue
@@ -42,7 +42,6 @@
       v-if="!loadingRandomTest && randomTestContent"
       :content-data="randomTestContent"
       :show-chips="false"
-      :show-title="false"
       button-next-text="Time to Test!"
     />
   </div>

--- a/app/components/common/header.vue
+++ b/app/components/common/header.vue
@@ -133,8 +133,9 @@
 
     <lazy-common-modal-base
       v-model:show-dialog="isAddOptionOpen"
-      title="What would you like to create?"
+      title="What would you like to publish?"
       subtitle="Choose a type. We will prepare the right form for you."
+      :max-width="560"
     >
       <menu-add-option-bottom-menu
         @close="isAddOptionOpen = false"

--- a/app/components/menu/AddOptionBottomMenu.vue
+++ b/app/components/menu/AddOptionBottomMenu.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="w-100 d-flex align-center justify-center flex-column mt-4">
-    <div class="w-100 d-flex flex-wrap justify-center ga-1 container-card">
+    <div class="w-100 d-flex flex-wrap justify-center ga-2 container-card">
       <nuxt-link
-        v-for="(item, index) in addOptions"
-        :key="index"
+        v-for="item in addOptions"
+        :key="item.title"
         :to="item.path"
-        class="card-add-option mt-1 d-flex flex-column align-center justify-center ga-1 rounded-xl"
+        :aria-label="`${item.title} — ${item.typeFile}`"
+        class="card-add-option d-flex flex-column align-center justify-center text-center ga-1 rounded-xl"
       >
         <div class="icon-div rounded-lg pa-2 d-flex align-center justify-center bg-primary100">
           <span
@@ -21,9 +22,9 @@
             {{ item.iconMd }}
           </v-icon>
         </div>
-        <span class="text-grey700 text-h6 font-weight-bold mt-1">{{ item.title }}</span>
+        <span class="card-option-title w-100 text-center text-grey700 text-h6 font-weight-bold mt-1">{{ item.title }}</span>
 
-        <span class="text-subtitle-2 font-weight-bold text-grey500 px-2 rounded-pill bg-grey100 mt-1 chip-type-file">
+        <span class="text-center text-subtitle-2 font-weight-bold text-grey500 px-2 rounded-pill bg-grey100 chip-type-file">
           {{ item.typeFile }}
         </span>
       </nuxt-link>
@@ -39,8 +40,8 @@
         </v-icon>
       </div>
       <div class="d-flex flex-column align-start justify-start ">
-        <span class="text-subtitle-1 font-weight-bold text-grey700">Earn points and income</span>
-        <span class="text-subtitle-2 font-weight-medium text-grey400">Publishing useful educational content rewards you with Gamatrain points and can generate income.</span>
+        <span class="text-subtitle-1 font-weight-bold text-grey700">Turn your expertise into reputation and income</span>
+        <span class="text-subtitle-2 font-weight-medium text-grey400">Publish educational content to boost your score and earn from sales.</span>
       </div>
     </div>
   </div>
@@ -50,24 +51,62 @@
 const route = useRoute()
 const emit = defineEmits(['close'])
 
-const addOptions = [
+interface AddOption {
+  path: string
+  title: string
+  typeFile: string
+  icon?: string
+  iconMd?: string
+}
+
+const addOptions: AddOption[] = [
   {
     path: '/user/paper/create',
-    title: 'Past Paper',
-    icon: 'icon-paper',
-    typeFile: 'PDF - DOCX',
+    title: 'Worksheet',
+    iconMd: 'md:description_outlined',
+    typeFile: 'PDF · DOCX',
   },
   {
-    path: '/user/question/create',
-    title: 'Q & A',
-    icon: 'icon-q-a',
-    typeFile: 'TEXT',
+    path: '/user/paper/create',
+    title: 'Predicted Paper',
+    icon: 'icon-paper',
+    typeFile: 'PDF · DOCX',
+  },
+  {
+    path: '/user/paper/create',
+    title: 'Study Guide',
+    iconMd: 'md:menu_book',
+    typeFile: 'PDF · DOCX',
+  },
+  {
+    path: '/user/paper/create',
+    title: 'Topical Questions',
+    iconMd: 'md:quiz_outlined',
+    typeFile: 'PDF · DOCX',
   },
   {
     path: '/user/multimedia/create',
-    title: 'Multimedia',
-    icon: 'icon-multimedia',
-    typeFile: 'MP4 - PPTX',
+    title: 'Video',
+    iconMd: 'md:videocam',
+    typeFile: 'MP4',
+  },
+  {
+    path: '/user/multimedia/create',
+    title: 'Presentation',
+    iconMd: 'md:slideshow',
+    typeFile: 'PPTX',
+  },
+  {
+    path: '/school/add',
+    title: 'School',
+    icon: 'icon-school',
+    typeFile: 'INFO',
+  },
+  {
+    path: '/user/question/create',
+    title: 'Q&A',
+    icon: 'icon-q-a',
+    typeFile: 'TEXT',
   },
   {
     path: '/user/blogs/create',
@@ -75,13 +114,6 @@ const addOptions = [
     iconMd: 'md:art_track',
     typeFile: 'HTML',
   },
-  {
-    path: '/school/add',
-    title: 'Schools',
-    icon: 'icon-school',
-    typeFile: 'INFO',
-  },
-
 ]
 
 watch(
@@ -99,7 +131,8 @@ watch(
 .card-add-option{
   width : 30%;
   max-width : 120px;
-  height : 120px;
+  height : 112px;
+  padding-top: 8px;
   border : 1px solid rgb(var(--v-theme-grey200));
   transition: 0.3s;
   text-decoration: none;
@@ -117,5 +150,27 @@ watch(
 .info-card{
   max-width : 320px;
   border : 1px solid rgb(var(--v-theme-primary100))
+}
+
+@media only screen and (max-width: 599.98px) {
+  .card-option-title {
+    padding-inline: 8px;
+    font-size: calc(1.25rem - 1px) !important;
+    line-height: 1.25rem;
+  }
+}
+
+@media only screen and (min-width: 960px) {
+  .container-card {
+    max-width: 480px;
+  }
+
+  .card-add-option {
+    max-width: 144px;
+  }
+
+  .card-option-title {
+    padding-inline: 8px;
+  }
 }
 </style>

--- a/app/components/menu/BottomNavMenu.vue
+++ b/app/components/menu/BottomNavMenu.vue
@@ -109,8 +109,9 @@
 
   <lazy-common-modal-base
     v-model:show-dialog="isAddOptionOpen"
-    title="What would you like to create?"
+    title="What would you like to publish?"
     subtitle="Choose a type. We will prepare the right form for you."
+    :max-width="560"
   >
     <menu-add-option-bottom-menu
       @close="isAddOptionOpen = false"

--- a/app/components/test/TestDetails.vue
+++ b/app/components/test/TestDetails.vue
@@ -35,7 +35,7 @@
           class="text-h6"
           icon="md:question_mark"
           :disabled="isPaymentComplete"
-          @click="openPaymentMdoal"
+          @click="openPaymentModal"
         />
       </div>
     </div>
@@ -45,7 +45,10 @@
       class="container-question w-100 d-flex flex-column align-start justift-start mt-6"
     >
       <div
-        class="test-text text-grey700 font-weight-semibold"
+        :class="[
+          'test-text text-grey700 font-weight-semibold',
+          { 'test-text-sm': smAndUp },
+        ]"
         v-html="contentData.question"
       />
       <img
@@ -100,7 +103,10 @@
             </v-icon>
           </div>
           <div
-            class="test-text font-weight-regular choise-text text-grey800 overflow-x-auto overflow-y-hidden"
+            :class="[
+              'test-text font-weight-regular choice-text text-grey800 overflow-x-auto overflow-y-hidden',
+              { 'test-text-sm': smAndUp },
+            ]"
             v-html="item.text"
           />
           <img
@@ -119,12 +125,12 @@
       class="w-100 mt-4 d-flex flex-column align-start justify-start px-2 px-sm-8"
     >
       <div
-        class="text-h4 font-weight-bold text-grey600"
+        :class="['test-text font-weight-bold text-grey600', { 'test-text-sm': smAndUp }]"
       >
         Solution:
       </div>
       <div
-        class="text-h6 text-sm-h4 text-grey800 mt-4"
+        :class="['test-text text-grey800 mt-4', { 'test-text-sm': smAndUp }]"
         v-html="contentData.answer_full"
       />
     </div>
@@ -364,7 +370,7 @@ onMounted(async () => {
   }
 })
 
-const openPaymentMdoal = async () => {
+const openPaymentModal = async () => {
   if (auth.isAuthenticated.value) {
     showCoinPaymentModal.value = true
   }
@@ -440,17 +446,17 @@ const loadNextTest = async () => {
   width: auto;
   max-width: 100%;
 }
-.container-choice{
+.container-choice {
   min-height: 24px;
 }
-.choice-div{
+.choice-div {
   min-width : 24px;
   min-height: 24px;
   max-width : 24px;
   max-height: 24px;
   font-size: 1.4rem;
 }
-.choise-text{
+.choice-text {
   line-height: 34px;
 }
 
@@ -458,9 +464,7 @@ const loadNextTest = async () => {
   font-size: 1.6rem;
 }
 
-@media only screen and (min-width: 600px) {
-  .test-text {
-    font-size: 1.8rem;
-  }
+.test-text-sm {
+  font-size: 1.8rem;
 }
 </style>

--- a/app/components/test/TestDetails.vue
+++ b/app/components/test/TestDetails.vue
@@ -10,6 +10,7 @@
         variant="flat"
         :class="chipClass"
         color="grey100"
+        :size="smAndUp ? 'large' : 'small'"
         :to="{
           path: '/search',
           query: chip.params,
@@ -21,12 +22,6 @@
       </v-chip>
     </div>
     <div class="w-100 d-flex align-center mt-4">
-      <div
-        v-if="showTitle"
-        class="text-h4 font-weight-bold text-grey600"
-      >
-        Question:
-      </div>
       <div
         v-if="contentData.answer_full.length > 0"
         class="w-100 d-flex align-center justify-end"
@@ -50,7 +45,7 @@
       class="container-question w-100 d-flex flex-column align-start justift-start mt-6"
     >
       <div
-        class="text-h5 text-sm-h4 text-grey700 font-weight-regular"
+        class="test-text text-grey700 font-weight-semibold"
         v-html="contentData.question"
       />
       <img
@@ -72,7 +67,7 @@
         >
           <div
             :class="[
-              'choice-div position-absolute left-0 top-0 text-h5 text-sm-h4 font-weight-medium text-grey800 d-flex align-center justify-center rounded-lg border-md border-solid border-opacity-100',
+              'choice-div font-weight-regular text-grey800 d-flex align-center justify-center rounded-lg border-md border-solid border-opacity-100',
               {
                 'border-grey200': getChoiceStatus(item.key) === 'default',
                 'border-success': getChoiceStatus(item.key) === 'success',
@@ -105,7 +100,7 @@
             </v-icon>
           </div>
           <div
-            class="text-h5 text-sm-h4 font-weight-semibold choise-text text-grey800 overflow-x-auto overflow-y-hidden"
+            class="test-text font-weight-regular choise-text text-grey800 overflow-x-auto overflow-y-hidden"
             v-html="item.text"
           />
           <img
@@ -134,19 +129,22 @@
       />
     </div>
 
-    <div class="w-100 d-flex align-center justify-center mt-6">
-      <v-btn
-        :disabled="!nextTestId && !ssrNextTestId"
-        :loading="nextTestLoading"
-        color="primary"
-        rounded="pill"
-        flat
-        :to="`/test/${ssrNextTest ? ssrNextTestId : nextTestId}`"
-      >
-        <span class="text-h5 font-weight-medium text-grey800 pl-5 pr-5">
-          {{ buttonNextText }}
-        </span>
-      </v-btn>
+    <div class="w-100 d-flex align-center justify-center justify-sm-start mt-6">
+      <div class="w-100 w-sm-25">
+        <v-btn
+          :disabled="!nextTestId && !ssrNextTestId"
+          :loading="nextTestLoading"
+          color="primary"
+          rounded="pill"
+          block
+          flat
+          :to="`/test/${ssrNextTest ? ssrNextTestId : nextTestId}`"
+        >
+          <span class="text-h5 font-weight-medium text-grey800">
+            {{ buttonNextText }}
+          </span>
+        </v-btn>
+      </div>
     </div>
 
     <lazy-test-success-coin-animation
@@ -178,12 +176,12 @@
 
 <script setup lang="ts">
 import type { QuestionDTO, NextQuestionDTO, ApiResult, TestTimeDTO, AppError } from '@/types'
+import { useDisplay } from 'vuetify/lib/composables/display.mjs'
 
 interface ITestDetail {
   contentData: QuestionDTO
   buttonNextText?: string
   showChips?: boolean
-  showTitle?: boolean
   ssrNextTest?: boolean
   ssrNextTestId?: string
 }
@@ -222,8 +220,10 @@ const isStartProcessShowAnswer = ref(false)
 const nextTestId = ref()
 const nextTestLoading = ref(false)
 
+const { smAndUp } = useDisplay()
+
 const chipClass = 'text-subtitle-1 px-3'
-const chipTextClass = 'text-grey500 text-h6 text-sm-h5'
+const chipTextClass = 'text-grey500 text-h6 text-sm-h5 font-weight-regular'
 
 const chips = computed(() => {
   const data = props.contentData
@@ -441,16 +441,26 @@ const loadNextTest = async () => {
   max-width: 100%;
 }
 .container-choice{
-  min-height: 30px;
+  min-height: 24px;
 }
 .choice-div{
-  min-width : 30px;
-  min-height: 30px;
-  max-width : 30px;
-  max-height: 30px;
+  min-width : 24px;
+  min-height: 24px;
+  max-width : 24px;
+  max-height: 24px;
+  font-size: 1.4rem;
 }
 .choise-text{
-  text-indent: 40px;
   line-height: 34px;
+}
+
+.test-text {
+  font-size: 1.6rem;
+}
+
+@media only screen and (min-width: 600px) {
+  .test-text {
+    font-size: 1.8rem;
+  }
 }
 </style>

--- a/app/components/test/TestDetails.vue
+++ b/app/components/test/TestDetails.vue
@@ -65,50 +65,52 @@
         <div
           v-for="item in answers"
           :key="item.key"
-          class="d-flex align-center flex-wrap ga-3 cursor-pointer position-relative container-choice"
+          class="w-100 d-flex flex-column align-start ga-2 cursor-pointer position-relative container-choice"
           @click="handleAnswerSelect(item.key)"
         >
-          <div
-            :class="[
-              'choice-div font-weight-regular text-grey800 d-flex align-center justify-center rounded-lg border-md border-solid border-opacity-100',
-              {
-                'border-grey200': getChoiceStatus(item.key) === 'default',
-                'border-success': getChoiceStatus(item.key) === 'success',
-                'border-lightError': getChoiceStatus(item.key) === 'error',
-                'border-primary': getChoiceStatus(item.key) === 'loading',
-              },
-            ]"
-          >
-            <v-progress-circular
-              v-if="getChoiceStatus(item.key) === 'loading'"
-              color="primary"
-              size="20"
-              indeterminate
-              :width="2"
+          <div class="w-100 d-flex flex-nowrap align-start ga-3">
+            <div
+              :class="[
+                'choice-div flex-shrink-0 font-weight-regular text-grey800 d-flex align-center justify-center rounded-lg border-md border-solid border-opacity-100',
+                {
+                  'border-grey200': getChoiceStatus(item.key) === 'default',
+                  'border-success': getChoiceStatus(item.key) === 'success',
+                  'border-lightError': getChoiceStatus(item.key) === 'error',
+                  'border-primary': getChoiceStatus(item.key) === 'loading',
+                },
+              ]"
+            >
+              <v-progress-circular
+                v-if="getChoiceStatus(item.key) === 'loading'"
+                color="primary"
+                size="20"
+                indeterminate
+                :width="2"
+              />
+              <span v-else-if="getChoiceStatus(item.key) === 'default'">{{ item.key }}</span>
+
+              <v-icon
+                v-else-if="getChoiceStatus(item.key) === 'success'"
+                color="success"
+              >
+                md:check
+              </v-icon>
+
+              <v-icon
+                v-else
+                color="lightError"
+              >
+                md:close
+              </v-icon>
+            </div>
+            <div
+              :class="[
+                'test-text flex-grow-1 font-weight-regular choice-text text-grey800 overflow-x-auto overflow-y-hidden',
+                { 'test-text-sm': smAndUp },
+              ]"
+              v-html="item.text"
             />
-            <span v-else-if="getChoiceStatus(item.key) === 'default'">{{ item.key }}</span>
-
-            <v-icon
-              v-else-if="getChoiceStatus(item.key) === 'success'"
-              color="success"
-            >
-              md:check
-            </v-icon>
-
-            <v-icon
-              v-else
-              color="lightError"
-            >
-              md:close
-            </v-icon>
           </div>
-          <div
-            :class="[
-              'test-text font-weight-regular choice-text text-grey800 overflow-x-auto overflow-y-hidden',
-              { 'test-text-sm': smAndUp },
-            ]"
-            v-html="item.text"
-          />
           <img
             v-if="item.file"
             class="answer-img mt-1"
@@ -457,7 +459,8 @@ const loadNextTest = async () => {
   font-size: 1.4rem;
 }
 .choice-text {
-  line-height: 34px;
+  min-width: 0;
+  line-height: 22px;
 }
 
 .test-text {

--- a/app/pages/test/[id].vue
+++ b/app/pages/test/[id].vue
@@ -13,7 +13,6 @@
       v-if="contentData"
       :content-data="contentData"
       :show-chips="true"
-      :show-title="true"
     />
 
     <v-row>

--- a/app/pages/user/paper/create.vue
+++ b/app/pages/user/paper/create.vue
@@ -94,7 +94,7 @@
         <div class="each-item d-flex flex-column align-start justify-start ga-1 mt-4">
           <common-gombo-box
             v-model="paper.classification"
-            label="Subject"
+            label="Classification"
             :items="classifications?.map((item) => {
               return {
                 id: item.id,


### PR DESCRIPTION
## Summary

This PR applies the changes in the requested order:

1. responsive test-detail changes from #1056
2. publishing-option improvements from #1058
3. mobile answer-option alignment improvements

The `Question:` heading remains removed, matching #1056. Option labels and answer text stay aligned on one row using Vuetify layout utilities, with scoped CSS only for values not covered by suitable utilities.

Merging this PR includes the changes from both #1056 and #1058.

## Testing

- focused ESLint on all changed Vue files
- `git diff --check`

Full build was not run.