### PR TITLE
fix(pwa): remove broken navigateFallback breaking SSR page refresh

### DIFF
--- a/app/pages/admin/schools/contributions/index.vue
+++ b/app/pages/admin/schools/contributions/index.vue
@@ -300,7 +300,6 @@ definePageMeta({
 })
 
 const { data: list, loadingGetData, totalCount, pageCount, getData } = useSchoolContributionAdmin()
-const { $toast } = useNuxtApp()
 const { formatLocal } = useDateTime()
 
 const headers = [

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -214,7 +214,6 @@ export default defineNuxtConfig({
       name: 'Gamatrain',
     },
     workbox: {
-      navigateFallback: '/',
       globPatterns: [],
       globIgnores: [
         '**/_payload.json',


### PR DESCRIPTION
## Summary
- On gamatrain.com, refreshing a page (outside incognito) throws `Uncaught (in promise) non-precached-url: non-precached-url :: [{"url":"/"}]` from the generated Workbox service worker, and subsequent client-side API calls fail to fire correctly.
- Root cause: `nuxt.config.js`'s `pwa.workbox.navigateFallback: '/'` tells the SW to intercept every navigation and serve a precached copy of `/`, but `globPatterns: []` means nothing — including `/` — is ever precached. Once a service worker from a prior visit controls the page, every refresh hits this broken fallback instead of loading normally.
- Confirmed: reproduces only in a normal browsing session (where the old SW is still registered and controlling the page); works fine in incognito (no prior SW registration).
- Fix: remove the broken `navigateFallback` entry. Precaching was already effectively disabled (`globPatterns: []`), so this doesn't reduce any working offline functionality — it just removes the dangling reference that throws.
- Also fixes an unrelated pre-existing lint error (`$toast` destructured but unused in `app/pages/admin/schools/contributions/index.vue`) that was blocking the pre-commit hook.

## Test plan
- [ ] `npx eslint` passes on both changed files (verified locally)
- [ ] Deploy preview / production and confirm no `non-precached-url` console error on refresh in a normal (non-incognito) browser session
- [ ] Confirm page data/APIs load correctly on hard refresh across a few routes (e.g. `/paper/[id]/[slug]`)