### PR TITLE
fix(seo): remove "Free" wording from meta descriptions

### DIFF
--- a/app/pages/paper/[id]/[[slug]].vue
+++ b/app/pages/paper/[id]/[[slug]].vue
@@ -219,7 +219,7 @@ const setMetaData = () => {
   }
   else {
     pageTitle.value = baseTitle
-    pageDescribe.value = `Free download of ${title} – ${base_title}, ${section_title} curriculum. Ideal for quick revision, practice, and exam prep.`
+    pageDescribe.value = `Download ${title} – ${base_title}, ${section_title} curriculum. Ideal for quick revision, practice, and exam prep.`
   }
 
   const ogImage = dto.thumb_pic

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -742,25 +742,25 @@ const metadata = computed(() => {
 
   const descriptionTemplates = {
     learnfiles: {
-      dynamic: `Free download list of ${joinTextTitles}  multimedia. ${descAppendText}`,
+      dynamic: `Download ${joinTextTitles}  multimedia. ${descAppendText}`,
     },
     test: {
-      dynamic: `Free download list of ${joinTextTitles} ${appendText}. ${descAppendText}`,
+      dynamic: `Download ${joinTextTitles} ${appendText}. ${descAppendText}`,
     },
     question: {
-      dynamic: `Free download list of ${joinTextTitles} Forum. ${descAppendText}`,
+      dynamic: `Download list of ${joinTextTitles} Forum. ${descAppendText}`,
     },
     azmoon: {
-      dynamic: `Free download list of ${joinTextTitles} Online test. ${descAppendText}`,
+      dynamic: `Download list of ${joinTextTitles} Online test. ${descAppendText}`,
     },
     dars: {
-      dynamic: `Free download list of ${joinTextTitles} Textbook. ${descAppendText}`,
+      dynamic: `Download list of ${joinTextTitles} Textbook. ${descAppendText}`,
     },
     teacher: {
       dynamic: `Browse qualified teachers and explore their profiles, experience, and subjects they teach.`,
     },
     default: {
-      dynamic: `Free download list of ${joinTextTitles} ${appendText}. ${descAppendText}`,
+      dynamic: `Download list of ${joinTextTitles} ${appendText}. ${descAppendText}`,
     },
   }
 


### PR DESCRIPTION
## Summary
- Removed "Free" wording from SEO meta descriptions on the past paper page and the search results page, since downloads are not actually free.

## Test plan
- [ ] Verify meta description tags render correctly on `/paper/[id]/[slug]` and `/search` pages