### PR TITLE
fix(seo): use consistent "download list of" wording across meta descriptions

### DIFF
--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -742,10 +742,10 @@ const metadata = computed(() => {
 
   const descriptionTemplates = {
     learnfiles: {
-      dynamic: `Download ${joinTextTitles}  multimedia. ${descAppendText}`,
+      dynamic: `Download list of ${joinTextTitles}  multimedia. ${descAppendText}`,
     },
     test: {
-      dynamic: `Download ${joinTextTitles} ${appendText}. ${descAppendText}`,
+      dynamic: `Download list of ${joinTextTitles} ${appendText}. ${descAppendText}`,
     },
     question: {
       dynamic: `Download list of ${joinTextTitles} Forum. ${descAppendText}`,


### PR DESCRIPTION
## Summary
- Aligns the `learnfiles` and `test` search meta description templates with the other templates (`question`, `azmoon`, `dars`, `default`) by using "Download list of ..." consistently.

## Test plan
- [ ] Verify meta description tags render correctly on `/search` for the learnfiles and test result types