### PR TITLE
fix(pwa, hydration): fix Vuetify SSR display mismatch and workbox precache error

### DIFF
--- a/app/plugins/vuetify.ts
+++ b/app/plugins/vuetify.ts
@@ -11,6 +11,7 @@ import { defineNuxtPlugin } from 'nuxt/app'
 export default defineNuxtPlugin(
   (app: { vueApp: { use: (plugin: unknown) => void } }) => {
     const vuetify = createVuetify({
+      ssr: true,
       theme: {
         defaultTheme: 'light',
         themes: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -220,6 +220,7 @@ export default defineNuxtConfig({
         '_nuxt/builds/**/*.json',
         '**/node_modules/**/*',
       ],
+      navigateFallback: undefined,
     },
     devOptions: {
       enabled: false,


### PR DESCRIPTION
## Summary
- Production console shows `Hydration completed but contains mismatches` and a service worker error `Uncaught (in promise) non-precached-url :: [{"url":"/"}]` (seen on e.g. https://gamatrain.com/paper/39575/Predicted-Paper-Checkpoint-Science0893-Paper-1-for-October-2026-pdf).
- `app/plugins/vuetify.ts` created `createVuetify()` without `ssr: true`. Vuetify's `useDisplay()` (used in ~50 components, including the paper/multimedia download buttons) computes viewport width as `0` on the server but reads the real `window.innerWidth` on the client during hydration, producing mismatched classes/`v-if` for any non-mobile visitor. Adding `ssr: true` keeps server/client display state in sync through hydration (Vuetify then corrects it right after, via its own Nuxt `app:suspense:resolve` hook).
- `nuxt.config.js`'s `pwa.workbox.globPatterns` is intentionally `[]` (SSR app, nothing to precache), but `navigateFallback` was left unset, so `@vite-pwa/nuxt` defaulted it to `'/'`. The generated service worker then called `createHandlerBoundToURL('/')` for a URL that was never precached, throwing `non-precached-url` on every load. Explicitly setting `navigateFallback: undefined` removes that broken navigation-fallback route from the generated `sw.js` (verified against workbox-build's own SW template, which gates that code behind `if (navigateFallback)`).

## Test plan
- [ ] Deploy to a preview/staging environment and confirm the hydration mismatch warning and `non-precached-url` service worker error no longer appear on paper/multimedia detail pages
- [ ] Spot-check mobile bottom-sheet download UI still renders correctly after hydration
- [ ] Confirm PWA install/offline behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)