### PR TITLE
fix(error page): correct 500 error image extension to webp

### DIFF
--- a/app/components/error/temp.vue
+++ b/app/components/error/temp.vue
@@ -5,7 +5,7 @@
     </h1>
 
     <img
-      :src="errorInfo[statusCode].image ?? `/images/error/error-500.svg`"
+      :src="errorInfo[statusCode].image ?? `/images/error/error-500.webp`"
       :alt="errorInfo[statusCode].title.toString() ?? '500'"
       height="300"
       width="300"
@@ -39,7 +39,7 @@ defineProps<IError>()
 const errorInfo = {
   500: {
     title: 500,
-    image: '/images/error/error-500.svg',
+    image: '/images/error/error-500.webp',
     subtitle: 'There was a problem on our side!',
   },
   404: {


### PR DESCRIPTION
## Summary
- The 500 error page (app/components/error/temp.vue) referenced /images/error/error-500.svg for both the errorInfo[500].image value and its fallback default, but only error-500.webp exists in public/images/error/ - every other status code in the same map already correctly uses .webp.
- This caused a 404 (Not Found) for error-500.svg and a broken image icon on the 500 error page in production.

## Test plan
- [ ] Trigger a 500 error page and confirm the image now loads correctly

Generated with Claude Code