### PR TITLE
fix(multimedia): comment out unused from_page and to_page fields in forms and types

### DIFF
--- a/app/composables/api/multimedia/useMultimedia.api.ts
+++ b/app/composables/api/multimedia/useMultimedia.api.ts
@@ -86,12 +86,12 @@ export const useMultimedia = () => {
     if (item.content_type) {
       payload.append('content_type', String(item.content_type || ''))
     }
-    if (item.from_page) {
-      payload.append('from_page', String(item.from_page || ''))
-    }
-    if (item.to_page) {
-      payload.append('to_page', String(item.to_page || ''))
-    }
+    // if (item.from_page) {
+    //   payload.append('from_page', String(item.from_page || ''))
+    // }
+    // if (item.to_page) {
+    //   payload.append('to_page', String(item.to_page || ''))
+    // }
     if (item.free_available) {
       payload.append('free_available', item.free_available ? '1' : '0')
     }

--- a/app/pages/user/multimedia/create.vue
+++ b/app/pages/user/multimedia/create.vue
@@ -193,7 +193,7 @@
           </div>
         </div>
 
-        <div class="w-100 d-flex flex-column align-start justify-start ga-1 mt-6 rounded-lg pa-2">
+        <!-- <div class="w-100 d-flex flex-column align-start justify-start ga-1 mt-6 rounded-lg pa-2">
           <span class="text-h5 text-grey700 font-weight-bold">Content cover</span>
           <span class="text-h6 text-grey600 font-weight-bold">
             What pages of the book does this content cover?
@@ -230,7 +230,7 @@
               class="w-100"
             />
           </div>
-        </div>
+        </div> -->
 
         <div class="w-100 d-flex align-center justify-start mt-4">
           <v-checkbox
@@ -329,8 +329,8 @@ const multimedia = ref<MultimediaForm>({
   title: '',
   description: '',
   content_type: '',
-  from_page: '',
-  to_page: '',
+  // from_page: '',
+  // to_page: '',
   free_available: false,
   file: '',
 })

--- a/app/pages/user/multimedia/edit/[id].vue
+++ b/app/pages/user/multimedia/edit/[id].vue
@@ -235,14 +235,14 @@
           </div>
         </div>
 
-        <div class="w-100 d-flex flex-column align-start justify-start ga-1 mt-6 rounded-lg pa-2">
+        <!-- <div class="w-100 d-flex flex-column align-start justify-start ga-1 mt-6 rounded-lg pa-2">
           <span class="text-h5 text-grey700 font-weight-bold">Content cover</span>
           <span class="text-h6 text-grey600 font-weight-bold">
             What pages of the book does this content cover?
           </span>
-        </div>
+        </div> -->
 
-        <div class="w-100 d-flex flex-wrap justify-start">
+        <!-- <div class="w-100 d-flex flex-wrap justify-start">
           <div class="each-item d-flex flex-column align-start justify-start ga-1 mt-4">
             <span class="text-h6 text-grey700 font-weight-medium">From page</span>
             <v-text-field
@@ -292,7 +292,7 @@
               </template>
             </v-text-field>
           </div>
-        </div>
+        </div> -->
 
         <!-- <div class="w-100 d-flex align-center justify-start mt-4">
           <v-checkbox
@@ -403,8 +403,8 @@ const multimedia = ref<MultimediaForm>({
   title: '',
   description: '',
   content_type: '',
-  from_page: '',
-  to_page: '',
+  // from_page: '',
+  // to_page: '',
   free_available: false,
   file: '',
 })
@@ -498,8 +498,8 @@ const applyMultimediaData = async (item: MultimediaDetailDTO) => {
   multimedia.value.title = item.title || ''
   multimedia.value.description = item.description || ''
   multimedia.value.content_type = item.content_type || ''
-  multimedia.value.from_page = item.from_page || ''
-  multimedia.value.to_page = item.to_page || ''
+  // multimedia.value.from_page = item.from_page || ''
+  // multimedia.value.to_page = item.to_page || ''
   multimedia.value.free_available = item.free_aggrement === '1'
   multimedia.value.file = ''
   existingFile.value = item.files || null

--- a/app/types/multimedia/index.ts
+++ b/app/types/multimedia/index.ts
@@ -6,8 +6,8 @@ export interface MultimediaCreateDTO {
   title: string
   description: string
   content_type: string | number
-  from_page: string | number
-  to_page: string | number
+  // from_page: string | number
+  // to_page: string | number
   free_available: boolean
   file: string
 }
@@ -19,8 +19,8 @@ export interface MultimediaEditDTO {
   title?: string
   description?: string
   content_type?: string | number
-  from_page?: string | number
-  to_page?: string | number
+  // from_page?: string | number
+  // to_page?: string | number
   free_available?: boolean
   file?: string
 }


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] My code follows the style guidelines of this project  
- [ ] I have performed a self-review of my own code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [ ] My changes generate no new warnings/errors  
- [ ] I have added tests that prove my fix is effective or that my feature works  
