### PR TITLE
fix(search): add March and May to Cambridge Primary/Lower Secondary month filter

### DIFF
--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -309,11 +309,15 @@ const specialMonths = {
     { id: 11, title: 'Oct/Nov' },
   ],
   6635: [
+    { id: 3, title: 'March' },
     { id: 4, title: 'April' },
+    { id: 5, title: 'May' },
     { id: 10, title: 'October' },
   ],
   6639: [
+    { id: 3, title: 'March' },
     { id: 4, title: 'April' },
+    { id: 5, title: 'May' },
     { id: 10, title: 'October' },
   ],
   // AQA-GCSE


### PR DESCRIPTION
## What
Adds **March** and **May** to the Month filter for the Cambridge **Primary** and **Lower Secondary** grades on the search page, alongside the existing April/October.

## Why
Reported: the filter for these two grades only exposed April and October, missing March and May.

## Where
`app/pages/search.vue` — `specialMonths` map, grade ids `6635` and `6639`.

## How to test
1. Go to `/search`
2. Select **Board = Cambridge**, **Grade = Primary** (or **Lower Secondary**)
3. Open the Month filter — should now show March, April, May, October

🤖 Generated with [Claude Code](https://claude.com/claude-code)